### PR TITLE
Add search as action option to parse app

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -984,7 +984,7 @@ else
     usage
 fi
 
-if [ "${ACTION}" == "install" ] || [ "${ACTION}" == "reinstall" ] || [ "${ACTION}" == "remove" ] || [ "${ACTION}" == "purge" ] || [ "${ACTION}" == "show" ]; then
+if [ "${ACTION}" == "install" ] || [ "${ACTION}" == "reinstall" ] || [ "${ACTION}" == "remove" ] || [ "${ACTION}" == "purge" ] || [ "${ACTION}" == "show" ] || [ "${ACTION}" == "search" ]; then
     if [ -n "${2}" ]; then
         APP="${2,,}"
     else


### PR DESCRIPTION
Without this addition the search was just echoing the list output, without indicating if the selected item is available