### PR TITLE
Add jabref installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The software below can be installed, updated and removed using `deb-get`.
 <img src=".github/github.png" align="top" width="20" /> [Heroic Games Launcher](https://heroicgameslauncher.com/) (`heroic`)<br />
 <img src=".github/github.png" align="top" width="20" /> [Insomnia](https://insomnia.rest/) (`insomnia`)<br />
 <img src=".github/github.png" align="top" width="20" /> [IRCCloud Desktop](https://www.irccloud.com/) (`irccloud-desktop`)<br />
-<img src=".github/direct.png" align="top" width="20" /> [JabRef](https://www.jabref.org/) (`jabref`)<br />
+<img src=".github/github.png" align="top" width="20" /> [JabRef](https://www.jabref.org/) (`jabref`)<br />
 <img src=".github/debian.png" align="top" width="20" /> [Jami](https://jami.net/) (`jami`)<br />
 <img src=".github/debian.png" align="top" width="20" /> [Jellyfin](https://jellyfin.org/) (`jellyfin`)<br />
 <img src=".github/debian.png" align="top" width="20" /> [Keybase](https://keybase.io/) (`keybase`)<br />

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The software below can be installed, updated and removed using `deb-get`.
 <img src=".github/github.png" align="top" width="20" /> [Heroic Games Launcher](https://heroicgameslauncher.com/) (`heroic`)<br />
 <img src=".github/github.png" align="top" width="20" /> [Insomnia](https://insomnia.rest/) (`insomnia`)<br />
 <img src=".github/github.png" align="top" width="20" /> [IRCCloud Desktop](https://www.irccloud.com/) (`irccloud-desktop`)<br />
+<img src=".github/direct.png" align="top" width="20" /> [JabRef](https://www.jabref.org/) (`jabref`)<br />
 <img src=".github/debian.png" align="top" width="20" /> [Jami](https://jami.net/) (`jami`)<br />
 <img src=".github/debian.png" align="top" width="20" /> [Jellyfin](https://jellyfin.org/) (`jellyfin`)<br />
 <img src=".github/debian.png" align="top" width="20" /> [Keybase](https://keybase.io/) (`keybase`)<br />

--- a/deb-get
+++ b/deb-get
@@ -927,8 +927,8 @@ function deb_jabref() {
     get_github_releases "https://api.github.com/repos/jabref/jabref/releases/latest"
     VERSION_PUBLISHED="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'/' -f8 | sed 's|v||')"
     URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
-    PRETTY_NAME="GitHub Desktop"
-    WEBSITE="https://desktop.github.com/"
+    PRETTY_NAME="JabRef"
+    WEBSITE="https://www.jabref.org/"
 }
 
 # Create an array of all the deb_ functions

--- a/deb-get
+++ b/deb-get
@@ -923,7 +923,7 @@ function deb_exodus() {
 }
 
 function deb_jabref() {
-    ARCHS_SUPPORTED="amd64 i386"
+    ARCHS_SUPPORTED="amd64"
     URL="https://builds.jabref.org/main/$(curl -s "https://builds.jabref.org/main/" | grep .deb | sed -e 's/.*amd64.deb">//g' | sed -e 's/<.*//g')"
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     PRETTY_NAME="JabRef"

--- a/deb-get
+++ b/deb-get
@@ -924,10 +924,11 @@ function deb_exodus() {
 
 function deb_jabref() {
     ARCHS_SUPPORTED="amd64"
-    URL="https://builds.jabref.org/main/$(curl -s "https://builds.jabref.org/main/" | grep .deb | sed -e 's/.*amd64.deb">//g' | sed -e 's/<.*//g')"
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
-    PRETTY_NAME="JabRef"
-    WEBSITE="https://www.jabref.org/"
+    get_github_releases "https://api.github.com/repos/jabref/jabref/releases/latest"
+    VERSION_PUBLISHED="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'/' -f8 | sed 's|v||')"
+    URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+    PRETTY_NAME="GitHub Desktop"
+    WEBSITE="https://desktop.github.com/"
 }
 
 # Create an array of all the deb_ functions

--- a/deb-get
+++ b/deb-get
@@ -922,6 +922,13 @@ function deb_exodus() {
     WEBSITE="https://exodus.com/"
 }
 
+function deb_jabref() {
+    ARCHS_SUPPORTED="amd64 i386"
+    URL="https://builds.jabref.org/main/$(curl -s "https://builds.jabref.org/main/" | grep .deb | sed -e 's/.*amd64.deb">//g' | sed -e 's/<.*//g')"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
+    PRETTY_NAME="JabRef"
+    WEBSITE="https://www.jabref.org/"
+}
 
 # Create an array of all the deb_ functions
 readonly APPS=($(declare -F | grep deb_ | sed 's|declare -f deb_||g' | sort))


### PR DESCRIPTION
I added the bibtex manager JabRef, which publishes .deb files at https://builds.jabref.org/main/