### PR TITLE
deb-get: add icaclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ cog.out(pretty_list)
 | [<img src=".github/github.png" align="top" width="20" />](https://heroicgameslauncher.com/) | `heroic` | <i>An Open Source GOG and Epic games launcher.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://gohugo.io/) | `hugo` | <i>Open-source static site generator.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://hyper.is/) | `hyper` | <i>A terminal built on web technologies.</i> |
+| [<img src=".github/debian.png" align="top" width="20" />]("https://www.citrix.com/en-gb/downloads/workspace-app/linux) | `icaclient` | <i>Enables users to access virtual desktops and hosted applications delivered by XenDesktop and XenApp.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://github.com/igdmapps/igdm) | `igdm` | <i>Continue your Instagram direct messages from your phone to your desktop.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://www.influxdata.com/products/influxdb-overview/) | `influxdb` | <i>Scalable datastore for metrics, events, and real-time analytics.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://www.influxdata.com/products/influxdb-overview/) | `influxdb2` | <i>Scalable datastore for metrics, events, and real-time analytics.</i> |

--- a/deb-get
+++ b/deb-get
@@ -121,7 +121,7 @@ function fancy_message() {
 
 function download_deb() {
     local URL="${1}"
-    local FILE="${URL##*/}"
+    local FILE="${2}"
 
     if ! ${ELEVATE} wget --quiet --continue --show-progress --progress=bar:force:noscroll "${URL}" -O "${CACHE_DIR}/${FILE}"; then
         fancy_message error "Failed to download ${URL}. Deleting ${CACHE_DIR}/${FILE}..."
@@ -200,7 +200,7 @@ function install_ppa() {
 
 function install_deb() {
     local URL="${1}"
-    local FILE="${URL##*/}"
+    local FILE="${FILE:-$URL##*/}"
     local STATUS=""
 
     if [ -z "${URL}" ]; then
@@ -210,14 +210,14 @@ function install_deb() {
 
     if ! package_is_installed "${APP}"; then
         eula
-        download_deb "${URL}"
+        download_deb "${URL}" "${FILE}"
         ${ELEVATE} apt-get -q=2 -o Dpkg::Progress-Fancy="1" -y install "${CACHE_DIR}/${FILE}"
     else
         if [ "${ACTION}" == "reinstall" ]; then
-            download_deb "${URL}"
+            download_deb "${URL}" "${FILE}"
             ${ELEVATE} apt-get -q=2 -o Dpkg::Progress-Fancy="1" -y --reinstall install "${CACHE_DIR}/${FILE}"
         elif dpkg --compare-versions "${VERSION_PUBLISHED}" gt "${VERSION_INSTALLED}"; then
-            download_deb "${URL}"
+            download_deb "${URL}" "${FILE}"
             ${ELEVATE} apt-get -q=2 -o Dpkg::Progress-Fancy="1" -y install "${CACHE_DIR}/${FILE}"
         else
             fancy_message info "${FILE} is up to date."
@@ -231,7 +231,7 @@ function install_deb() {
 function remove_deb() {
     local APP="${1}"
     local REMOVE="${2:-remove}"
-    local FILE="${URL##*/}"
+    local FILE="${FILE:-$URL##*/}"
     local STATUS=""
 
     if package_is_installed "${APP}"; then
@@ -2236,6 +2236,17 @@ function deb_blanket() {
     PRETTY_NAME="Blanket"
     WEBSITE="https://github.com/rafaelmardojai/blanket"
     SUMMARY="Improve focus and increase your productivity by listening to different sounds. Or allows you to fall asleep in a noisy environment."
+}
+
+function deb_icaclient() {
+    URL_PRE=$(curl https://www.citrix.com/en-gb/downloads/workspace-app/ | grep "Citrix Workspace app.*Linux" | sort -r -k 5 | grep -v -i tech | head -n 1 | cut -d'"' -f2)
+    URL="http:$(curl https://www.citrix.com/${URL_PRE} | grep ctx-dl-lin | cut -d'"' -f10 | grep icaclient.*${HOST_ARCH}.*deb)"
+    FILE=$(echo "${URL}" | sed 's/.deb?.*/.deb/g')
+    FILE=${FILE##*/}
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f 2)"
+    PRETTY_NAME="Citrix Workspace App"
+    WEBSITE="https://www.citrix.com/en-gb/downloads/workspace-app/linux"
+    SUMMARY="Enables users to access virtual desktops and hosted applications delivered by XenDesktop and XenApp."
 }
 
 # Create an array to track those deb_ functions being loaded by this script


### PR DESCRIPTION
First stab at this.

I need the FILE variable to be visible to the other functions that is being used, and the as the download URL would look similar to

http://downloads.citrix.com/20613/icaclient_22.3.0.24_amd64.deb?__gda__=exp=1651226310~acl=/*~hmac=177b2a403e01e0199fcb32f5e3b0fa2e995657b5c31322e07afc96e593f73cf5

I can get 

```
sudo ./deb-get show icaclient
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  175k    0  175k    0     0    99k      0 --:--:--  0:00:01 --:--:--   99k
Citrix Workspace app
  Package:	icaclient
  Updater:	deb-get
  Installed:	22.3.0.24
  Published:	22.3.0.24
  Architecture:	amd64
  Download:	http://downloads.citrix.com/20613/icaclient_22.3.0.24_amd64.deb?__gda__=exp=1651226310~acl=/*~hmac=177b2a403e01e0199fcb32f5e3b0fa2e995657b5c31322e07afc96e593f73cf5
  Website:	https://www.citrix.com/en-gb/downloads/workspace-app/linux
```

Many of the functions use the regex+replacement, but this won't work for this, and needs an alternative, as I have specified in the deb_icaclient function

```
local FILE="${URL##*/}"
```