### PR TITLE
Make sure curl is installed before running the curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ release pages.
 Use `deb-get` to install `deb-get`
 
 ```bash
-curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
+sudo apt install curl && curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
 ```
 
 Alternatively, you can [download the `.deb` of `deb-get` from the releases page](https://github.com/wimpysworld/deb-get/releases)


### PR DESCRIPTION
This prepends an extra command to the deb-get-to-install-deb-get installation method to guarantee the user installs curl first in case curl is not installed yet.