### PR TITLE
Added alias for `sudo deb-get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ release pages.
 Use `deb-get` to install `deb-get`
 
 ```bash
-sudo apt install curl && curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
+sudo apt install curl && curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get && echo 'alias deb-get="sudo deb-get"' >> ~/.`echo $0`rc
 ```
 
 Alternatively, you can [download the `.deb` of `deb-get` from the releases page](https://github.com/wimpysworld/deb-get/releases)

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ and install it manually.
 Here's an example of how to install Google Chrome.
 
 ```bash
-sudo deb-get install google-chrome-stable
+deb-get install google-chrome-stable
 ```
 
-You can see what applications are supported by using `sudo deb-get list` or you
-can search the available applications with `sudo deb-get search <app>`
+You can see what applications are supported by using `deb-get list` or you
+can search the available applications with `deb-get search <app>`
 
 You can upgrade packages installed using `deb-get` by running
-`sudo deb-get upgrade`.
+`deb-get upgrade`.
 
 ```
 deb-get {update | upgrade | show pkg | install pkg | reinstall pkg | remove pkg
@@ -107,11 +107,11 @@ since 2015.
 
 The software below can be installed, updated and removed using `deb-get`.
 
-- `sudo deb-get install <packagename>`
-- `sudo deb-get update`
-- `sudo deb-get upgrade`
-- `sudo deb-get remove <packagename>`
-- `sudo deb-get purge <packagename>`
+- `deb-get install <packagename>`
+- `deb-get update`
+- `deb-get upgrade`
+- `deb-get remove <packagename>`
+- `deb-get purge <packagename>`
 
 <img src=".github/debian.png" align="top" width="20" /> [1Password](https://1password.com/) (`1password`)<br />
 <img src=".github/github.png" align="top" width="20" /> [AntiMicroX](https://antimicrox.github.io/) (`antimicrox`)<br />


### PR DESCRIPTION
I am using `echo $0` for telling what's the current shell, and using the name for the rc file. Seems to work fine on ZorinOS but need confirmation from users of other operating systems.

This PR mainly includes changes to the README:
- Adding an alias command in the installation, to alias `deb-get` as `sudo deb-get`.
- Removing all references of sudo that aren't needed.