### PR TITLE
Support doas

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1082,10 +1082,12 @@ if [ "$(id -u)" -ne 0 ]; then
   fancy_message fatal "You must use sudo to run $(basename ${0})."
 fi
 
-if [ -z "${SUDO_USER}" ]; then
-  fancy_message fatal "You must use sudo to run $(basename ${0})."
+if [ "${SUDO_USER}" ]; then
+  USER_HOME=$(getent passwd "${SUDO_USER}" | cut -d: -f6)
+elif [ "${DOAS_USER}" ]; then
+  USER_HOME=$(getent passwd "${DOAS_USER}" | cut -d: -f6)
 else
-  SUDO_HOME=$(getent passwd "${SUDO_USER}" | cut -d: -f6)
+  fancy_message fatal "You must use sudo to run $(basename ${0})."
 fi
 
 if ! command -v lsb_release 1>/dev/null; then


### PR DESCRIPTION
`doas` is a minimal alternative to `sudo`. It is popular in the BSD world, but some people use it on Linux too as it is simpler to configure and has a smaller attack surface.

Also renamed `SUDO_HOME` to `USER_HOME` as it's more general and descriptive. The variable doesn't seem used at all though.

Related to #106 