### PR TITLE
Added support for Tidal-hifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The software below can be installed, updated and removed using `deb-get`.
 <img src=".github/debian.png" align="top" width="20" /> [Microsoft Teams](https://www.microsoft.com/microsoft-teams/group-chat-software) (`teams`)<br />
 <img src=".github/direct.png" align="top" width="20" /> [TeamViewer](https://www.teamviewer.com/) (`teamviewer`)<br />
 <img src=".github/debian.png" align="top" width="20" /> [Terraform](https://www.terraform.io/) (`terraform`)<br />
+<img src=".github/github.png" align="top" width="20" /> [Tidal-hifi](https://github.com/mastermindzh/tidal-hifi) (`tidal-hifi`)<br />
 <img src=".github/direct.png" align="top" width="20" /> [Tixati](https://www.tixati.com/) (`tixati`)<br />
 <img src=".github/github.png" align="top" width="20" /> [Trivy](https://aquasecurity.github.io/trivy/) (`trivy`)<br />
 <img src=".github/launchpad.png" align="top" width="20" /> [Ubuntu-Make](https://github.com/ubuntu/ubuntu-make/) (`ubuntu-make`)<br />

--- a/deb-get
+++ b/deb-get
@@ -1125,6 +1125,14 @@ function deb_vuescan() {
     WEBSITE="https://www.hamrick.com/"
 }
 
+function deb_tidal-hifi() {
+    get_github_releases "https://api.github.com/repos/Mastermindzh/tidal-hifi/releases/latest"
+    VERSION_PUBLISHED="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'_' -f2)"
+    URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+    PRETTY_NAME="Tidal-hifi"
+    WEBSITE="https://github.com/Mastermindzh/tidal-hifi"
+}
+
 # Create an array of all the deb_ functions
 readonly APPS=($(declare -F | grep deb_ | sed 's|declare -f deb_||g' | sort))
 export CACHE_DIR="/var/cache/deb-get"


### PR DESCRIPTION
Tidal-hifi is an electron-wrapped version of listen.tidal.com. It supports high fidelity playbacks thanks to its inclusion of widevine.

* Github repository (https://github.com/Mastermindzh/tidal-hifi)
* Under active development (4 releases in past month; 25 releases in total since Oct. 2019)
* PR includes update of README and deb-get itself