### PR TITLE
vuescan: fix arch recognition

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1293,7 +1293,7 @@ function deb_vuescan() {
     ARCHS_SUPPORTED="amd64 arm64 i386"
     local ARCH_VER
     case ${HOST_ARCH} in
-        x86_64)  ARCH_VER=x64;;
+        amd64)   ARCH_VER=x64;;
         aarch64) ARCH_VER=a64;;
         i386)    ARCH_VER=x32;;
     esac


### PR DESCRIPTION
Tried to install vuescan, but arch in Ubuntu/Debian is recognised as amd64 and not x86_64, so updating this to reflect this