### PR TITLE
deb-get: Add picocrypt. Close #167

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The software below can be installed, updated and removed using `deb-get`.
 <img src=".github/github.png" align="top" width="20" /> [ONLYOFFICE Desktop Editors](https://www.onlyoffice.com/en/desktop.aspx) (`onlyoffice-desktopeditors`) - <i>Free desktop office suite for document editing and collaboration.</i><br />
 <img src=".github/debian.png" align="top" width="20" /> [Opera](https://www.opera.com/) (`opera-stable`) - <i>Faster, safer and smarter than default browsers.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [Pandoc](https://pandoc.org/) (`pandoc`) - <i>A universal document converter.</i><br />
+<img src=".github/github.png" align="top" width="20" /> [Picocrypt](https://github.com/HACKERALERT/Picocrypt/) (`picocrypt`) - <i>A very small, very simple, yet very secure encryption tool.</i><br />
 <img src=".github/debian.png" align="top" width="20" /> [Plex](https://www.plex.tv/) (`plexmediaserver`) - <i>Stream Movies and TV Shows.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [PowerShell](https://docs.microsoft.com/powershell/) (`powershell`) - <i>Cross-platform automation and configuration tool/framework and optimized for dealing with structured data.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [Quickemu](https://github.com/quickemu-project/quickemu) (`quickemu`) - <i>Quickly create and run optimised Windows, macOS and Linux desktop virtual machines.</i><br />

--- a/deb-get
+++ b/deb-get
@@ -1324,6 +1324,16 @@ function deb_expressvpn() {
     SUMMARY="Popular VPN software"
 }
 
+function deb_picocrypt() {
+    ARCHS_SUPPORTED="amd64"
+    get_github_releases "https://api.github.com/repos/HACKERALERT/Picocrypt/releases/latest"
+    VERSION_PUBLISHED="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'/' -f8)"
+    URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+    PRETTY_NAME="Picocrypt"
+    WEBSITE="https://github.com/HACKERALERT/Picocrypt/"
+    SUMMARY="A very small, very simple, yet very secure encryption tool."
+}
+
 # Create an array of all the deb_ functions
 readonly APPS=($(declare -F | grep deb_ | sed 's|declare -f deb_||g' | sort))
 export CACHE_DIR="/var/cache/deb-get"


### PR DESCRIPTION
Get Picocrypt from the official Github repository