### PR TITLE
Safing portmaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The software below can be installed, updated and removed using `deb-get`.
 <img src=".github/debian.png" align="top" width="20" /> [Plex](https://www.plex.tv/) (`plexmediaserver`) - <i>Stream Movies and TV Shows.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [Polychromatic](https://polychromatic.app/) (`polychromatic`) - <i>Frontend for OpenRazer that enables Razer devices to control lighting effects and more.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [PowerShell](https://docs.microsoft.com/powershell/) (`powershell`) - <i>Cross-platform automation and configuration tool/framework and optimized for dealing with structured data.</i><br />
+<img src=".github/direct.png" align="top" width="20" /> [Portmaster](https://safing.io/portmaster/) (`portmaster`) - <i>Portmaster is a free and open-source application that puts you back in charge over all your computer's network connections.</i><br />
 <img src=".github/debian.png" align="top" width="20" /> [ProtonVPN](https://protonvpn.com/) (`protonvpn`) - <i>High-speed Swiss VPN that safeguards your privacy.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [Quickemu](https://github.com/quickemu-project/quickemu) (`quickemu`) - <i>Quickly create and run optimised Windows, macOS and Linux desktop virtual machines.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [Quickgui](https://github.com/quickemu-project/quickgui) (`quickgui`) - <i>A Flutter frontend for Quickemu.</i><br />

--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ The software below can be installed, updated and removed using `deb-get`.
 <img src=".github/github.png" align="top" width="20" /> [Picocrypt](https://github.com/HACKERALERT/Picocrypt/) (`picocrypt`) - <i>A very small, very simple, yet very secure encryption tool.</i><br />
 <img src=".github/debian.png" align="top" width="20" /> [Plex](https://www.plex.tv/) (`plexmediaserver`) - <i>Stream Movies and TV Shows.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [Polychromatic](https://polychromatic.app/) (`polychromatic`) - <i>Frontend for OpenRazer that enables Razer devices to control lighting effects and more.</i><br />
-<img src=".github/github.png" align="top" width="20" /> [PowerShell](https://docs.microsoft.com/powershell/) (`powershell`) - <i>Cross-platform automation and configuration tool/framework and optimized for dealing with structured data.</i><br />
 <img src=".github/direct.png" align="top" width="20" /> [Portmaster](https://safing.io/portmaster/) (`portmaster`) - <i>Portmaster is a free and open-source application that puts you back in charge over all your computer's network connections.</i><br />
+<img src=".github/github.png" align="top" width="20" /> [PowerShell](https://docs.microsoft.com/powershell/) (`powershell`) - <i>Cross-platform automation and configuration tool/framework and optimized for dealing with structured data.</i><br />
 <img src=".github/debian.png" align="top" width="20" /> [ProtonVPN](https://protonvpn.com/) (`protonvpn`) - <i>High-speed Swiss VPN that safeguards your privacy.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [Quickemu](https://github.com/quickemu-project/quickemu) (`quickemu`) - <i>Quickly create and run optimised Windows, macOS and Linux desktop virtual machines.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [Quickgui](https://github.com/quickemu-project/quickgui) (`quickgui`) - <i>A Flutter frontend for Quickemu.</i><br />

--- a/deb-get
+++ b/deb-get
@@ -1562,6 +1562,14 @@ function deb_tailscale() {
     SUMMARY="Zero config VPN. Works on any device, manages firewall rules for you, and works from anywhere."
 }
 
+function deb_portmaster() {
+    VERSION_PUBLISHED="$(curl -s https://api.github.com/repos/safing/portmaster/releases/latest | grep -E '"name":' | sed -E 's/[",]//g' | cut -d: -f2 | sed 's/ //g')"
+    URL="https://updates.safing.io/latest/linux_amd64/packages/portmaster-installer.deb"
+    PRETTY_NAME="Portmaster"
+    WEBSITE="https://safing.io/portmaster/"
+    SUMMARY="Portmaster is a free and open-source application that puts you back in charge over all your computer's network connections."
+}
+
 function deb_vuescan() {
     ARCHS_SUPPORTED="amd64 arm64 i386"
     local ARCH_VER


### PR DESCRIPTION
Add [portmaster](https://safing.io/portmaster/)

Caveat, you need to run `sudo apt-get install -y -f` to install the necesssary dependencies (`libnetfilter-queue1`)