### PR TITLE
add YouTube Music Desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The software below can be installed, updated and removed using `deb-get`.
 <img src=".github/github.png" align="top" width="20" /> [Whalebird](https://whalebird.social/) (`whalebird`) - <i>A Mastodon, Pleroma, and Misskey client for desktop application.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [WhatsApp for Linux](https://github.com/eneshecan/whatsapp-for-linux) (`whatsapp-for-linux`) - <i>An unofficial WhatsApp desktop application for Linux.</i><br />
 <img src=".github/debian.png" align="top" width="20" /> [Wire](https://wire.com/) (`wire-desktop`) - <i>Secure collaboration platform.</i><br />
+<img src=".github/github.png" align="top" width="20" /> [YouTube Music Desktop](https://th-ch.github.io/youtube-music/) (`youtube-music`) - <i>Open source, cross-platform, unofficial YouTube Music Desktop App.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [yq](https://mikefarah.gitbook.io/yq) (`yq`) - <i>A lightweight and portable command-line YAML processor.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [Zenith](https://github.com/bvaisvil/zenith) (`zenith`) - <i>Sort of like 'top' or 'htop' but with zoom-able charts.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [Zettlr](https://www.zettlr.com/) (`zettlr`) - <i>A Markdown Editor for the 21st century.</i><br />

--- a/deb-get
+++ b/deb-get
@@ -1773,6 +1773,16 @@ function deb_yq() {
     SUMMARY="A lightweight and portable command-line YAML processor."
 }
 
+function deb_youtube-music() {
+    ARCHS_SUPPORTED="amd64"
+    get_github_releases "https://api.github.com/repos/th-ch/youtube-music/releases/latest"
+    VERSION_PUBLISHED="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'/' -f8 | sed 's|v||')"
+    URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+    PRETTY_NAME="youtube-music"
+    WEBSITE="https://th-ch.github.io/youtube-music/"
+    SUMMARY="Open source, cross-platform, unofficial YouTube Music Desktop App with built-in ad blocker and downloader."
+}
+
 # Create an array of all the deb_ functions
 readonly APPS=($(declare -F | grep deb_ | sed 's|declare -f deb_||g' | sort))
 export CACHE_DIR="/var/cache/deb-get"


### PR DESCRIPTION
They build a snap but don't publish it in the snap store.  Not to be confused with youtube-music-desktop-app that IS in the snap store but is a different project (how can you confuse them with such distinctive names!).  That one doesn't have a deb, and development seems to have slowed to a snail, so I use this one.  