### PR TITLE
added mergerfs and check for supported codenames

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1783,6 +1783,18 @@ function deb_youtube-music() {
     SUMMARY="Open source, cross-platform, unofficial YouTube Music Desktop App with built-in ad blocker and downloader."
 }
 
+function deb_mergerfs() {
+    ARCHS_SUPPORTED="amd64 arm64 armhf"
+    get_github_releases "https://api.github.com/repos/trapexit/mergerfs/releases/latest"
+    VERSION_PUBLISHED="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep ${OS_CODENAME}_${HOST_ARCH} | cut -d'_' -f4 | sed -E "s/([0-9])\.ubuntu/\1~ubuntu/")"
+    # TODO When https://github.com/wimpysworld/deb-get/issues/125 shakes out should add the debian packages
+    CODENAMES_SUPPORTED=($(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json"| grep ${HOST_ARCH} | cut -d'"' -f4 | sed -n "s/^.*ubuntu-\(\S*\)_.*/\1/p"))
+    URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep ${UBUNTU_CODENAME}_${HOST_ARCH} | cut -d'"' -f4)"
+    PRETTY_NAME="mergerfs"
+    WEBSITE="https://github.com/trapexit/mergerfs"
+    SUMMARY="A featureful union filesystem."
+}
+
 # Create an array of all the deb_ functions
 readonly APPS=($(declare -F | grep deb_ | sed 's|declare -f deb_||g' | sort))
 export CACHE_DIR="/var/cache/deb-get"
@@ -1871,9 +1883,13 @@ case "${ACTION}" in
         for APP in "${@,,}"; do
             validate_deb "${APP}"
             if [[ "${ARCHS_SUPPORTED}" != *"${HOST_ARCH}"* ]]; then
-                fancy_message error "${APP} is not supported on ${HOST_ARCH}."
-                return
+                fancy_message fatal "${APP} is not supported on ${HOST_ARCH}."
             fi
+
+            if [ -n "${CODENAMES_SUPPORTED}" ] && ! [[ "${CODENAMES_SUPPORTED[*]}" =~ "${OS_CODENAME}" ]]; then
+                fancy_message fatal "${APP} is not supported on ${OS_ID_PRETTY} ${OS_CODENAME^}."
+            fi
+
             case ${METHOD} in
                 direct|github|website) install_deb "${URL}";;
                 apt) install_apt;;


### PR DESCRIPTION
mergerfs only publishes packages for LTS releases, so I added a little logic that checks for what codenames they have published and compares to current and gives an error if it's an interim release.  Should be reusable if any future packages do the same.  Not sure how you would have liked to handle that situation, or if at all, but I took a stab at it!
