### PR TITLE
Add OpenRGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The software below can be installed, updated and removed using `deb-get`.
 <img src=".github/direct.png" align="top" width="20" /> [ocenaudio](https://www.ocenaudio.com/) (`ocenaudio`) - <i>Easy, fast and powerful audio editor.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [ONLYOFFICE Desktop Editors](https://www.onlyoffice.com/en/desktop.aspx) (`onlyoffice-desktopeditors`) - <i>Free desktop office suite for document editing and collaboration.</i><br />
 <img src=".github/launchpad.png" align="top" width="20" /> [OpenRazer](https://openrazer.github.io/) (`openrazer-meta`) - <i>Open source driver and user-space daemon that allows you to manage Razer peripherals.</i><br />
+<img src=".github/direct.png" align="top" width="20" /> [OpenRGB](https://openrgb.org/) (`openrgb`) - <i>Open source RGB lighting control that doesn't depend on manufacturer software.</i><br />
 <img src=".github/debian.png" align="top" width="20" /> [Opera](https://www.opera.com/) (`opera-stable`) - <i>Faster, safer and smarter than default browsers.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [P3X OneNote](https://www.corifeus.com/onenote) (`p3x-onenote`) - <i>A Linux compatible version of OneNote.</i><br />
 <img src=".github/github.png" align="top" width="20" /> [Pandoc](https://pandoc.org/) (`pandoc`) - <i>A universal document converter.</i><br />

--- a/deb-get
+++ b/deb-get
@@ -1783,6 +1783,24 @@ function deb_youtube-music() {
     SUMMARY="Open source, cross-platform, unofficial YouTube Music Desktop App with built-in ad blocker and downloader."
 }
 
+function deb_openrgb() {
+    ARCHS_SUPPORTED="amd64 i386 armhf"
+
+    case "${UBUNTU_CODENAME}" in
+        focal)
+            URL="https://openrgb.org/$(curl -s https://openrgb.org/releases.html | grep -o "\"releases/.*/openrgb_.*_${HOST_ARCH}.*buster_.*\.deb\"" | sort --version-sort | tail -n1 | cut -d "\"" -f 2)"
+        ;;
+        *)
+            URL="https://openrgb.org/$(curl -s https://openrgb.org/releases.html | grep -o "\"releases/.*/openrgb_.*_${HOST_ARCH}.*bullseye_.*\.deb\"" | sort --version-sort | tail -n1 | cut -d "\"" -f 2)"
+        ;;
+    esac
+
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d "_" -f 3)"
+    PRETTY_NAME="OpenRGB"
+    WEBSITE="https://openrgb.org/"
+    SUMMARY="Open source RGB lighting control that doesn't depend on manufacturer software."
+}
+
 # Create an array of all the deb_ functions
 readonly APPS=($(declare -F | grep deb_ | sed 's|declare -f deb_||g' | sort))
 export CACHE_DIR="/var/cache/deb-get"


### PR DESCRIPTION
I noticed that the latest version is not working with Ubuntu 22.04, but the one before it is working. Should I always fetch the second to last version instead?