### PR TITLE
mattermost-desktop: don't grab rc packages

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1106,7 +1106,7 @@ function deb_mailspring() {
 
 function deb_mattermost-desktop() {
     get_github_releases "https://api.github.com/repos/mattermost/desktop/releases"
-    VERSION_PUBLISHED="$(grep "browser_download_url" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'/' -f8 | sed 's/v//')"
+    VERSION_PUBLISHED="$(grep "browser_download_url" "${CACHE_DIR}/${APP}.json" | grep -v -e rc | head -n1 | cut -d'"' -f4 | cut -d'/' -f8 | sed 's/v//')"
     URL="$(curl https://github.com/mattermost/desktop/releases/ | grep "//releases.*${VERSION_PUBLISHED}.*${HOST_ARCH}.deb" | head -n 1 | cut -d\" -f 2)"
     PRETTY_NAME="Mattermost Desktop"
     WEBSITE="https://mattermost.com/"


### PR DESCRIPTION
The last update also grabbed RC versions, so this eliminates that