### PR TITLE
Clean should purge the cache directory so that deb-get can update itself

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2453,7 +2453,7 @@ case "${ACTION}" in
         ls -lh "${CACHE_DIR}/";;
     clean)
         elevate_privs
-        ${ELEVATE} rm -v "${CACHE_DIR}"/*.deb;;
+        ${ELEVATE} rm -v "${CACHE_DIR}"/*.json;;
     show)
         for APP in "${@,,}"; do
             validate_deb "${APP}"

--- a/deb-get
+++ b/deb-get
@@ -2453,6 +2453,7 @@ case "${ACTION}" in
         ls -lh "${CACHE_DIR}/";;
     clean)
         elevate_privs
+        ${ELEVATE} rm -v "${CACHE_DIR}"/*.deb;;
         ${ELEVATE} rm -v "${CACHE_DIR}"/*.json;;
     show)
         for APP in "${@,,}"; do


### PR DESCRIPTION
deb-get could not update itself after using deb-get clean (only tried deleting .deb files). This change would ensure .json files are deleted to allow deb-get to update itself when a new release is created.