### PR TITLE
Correct installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ release pages.
 
 ## Install
 
-Use `deb-get` to install `deb-get`.
+Use `dpkg` to install `deb-get`.
 
 ```bash
 sudo apt install curl


### PR DESCRIPTION
As is currently on main, users may not be able to install deb-get if deb-get from main is broken. Therefore installation instructions should be based on the latest release and not on a link to a file on main.

This change also requires to use dpkg to install deb-get, as only deb, zip and tar.gz are available as release assets.

This changes makes does the following:
1. use github api and some basic shell foo, to get the asset url for the deb-get package,
2. use curl to download the deb package
3. use dpkg to install deb-get