### PR TITLE
getting debian working

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2406,9 +2406,10 @@ esac
 
 OS_CODENAME=$(lsb_release --codename --short)
 if [ -e /etc/os-release ]; then
+#Debian VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2 | sed 's/"//g')
     UPSTREAM_ID="$(grep "^ID=" /etc/os-release | cut -d'=' -f2)"
     case "${UPSTREAM_ID}" in
-        debian) UPSTREAM_CODENAME=$(grep DEBIAN_CODENAME /etc/os-release | cut -d'=' -f2);;
+        debian) UPSTREAM_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2);;
         ubuntu) UPSTREAM_CODENAME=$(grep UBUNTU_CODENAME /etc/os-release | cut -d'=' -f2);;
         *) UPSTREAM_CODENAME="";;
     esac


### PR DESCRIPTION
There is no DEBIAN_ in `/etc/os-release` on debian bullseye
Both Ubuntu and Debian seem to use VERSION_CODENAME
