### PR TITLE
New URL for GitKraken

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1418,7 +1418,7 @@ function deb_vivaldi-stable() {
 
 function deb_gitkraken() {
     if [ "${ACTION}" != "prettylist" ]; then
-        VERSION_PUBLISHED="$(curl -s "https://support.gitkraken.com/release-notes/current/" | grep 'id="version-' | head -n1 | sed -e 's/<[^>]*>//g' | cut -d' ' -f2)"
+        VERSION_PUBLISHED="$(curl -s "https://help.gitkraken.com/gitkraken-client/current/" | grep 'id="version-' | head -n1 | sed -e 's/<[^>]*>//g' | cut -d' ' -f2)"
     fi
     URL="https://release.gitkraken.com/linux/gitkraken-amd64.deb"
     PRETTY_NAME="GitKraken"


### PR DESCRIPTION
The url for GitKraken has changed, and `deb-get` was unable to see the updated version.