### PR TITLE
Protect Ubuntus from derivatives fix

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2427,7 +2427,9 @@ if [ -e /etc/os-release ]; then
     UPSTREAM_ID="$(grep "^ID=" /etc/os-release | cut -d'=' -f2)"
     UPSTREAM_ID_LIKE="$(grep "^ID_LIKE=" /etc/os-release | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1)"
     if [ ! -z "${UPSTREAM_ID_LIKE}" ]; then
-        UPSTREAM_ID="${UPSTREAM_ID_LIKE}"
+        if [ ! ${OS_ID} == "Ubuntu" ]; then
+            UPSTREAM_ID="${UPSTREAM_ID_LIKE}"
+        fi
     fi
     case "${UPSTREAM_ID}" in
         debian) UPSTREAM_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2);;


### PR DESCRIPTION
This has been tested on Ubuntu Mate, POP, Mint, MX, KDE Neon and Debian and fixes ppa installs on Ubuntu (devcontainer) and Ubuntu Mate and tested ubuntu derivatives
closes #365 