### PR TITLE
Try source of apt-add-repository to determine appropriate parameters

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -181,7 +181,12 @@ function install_apt() {
 }
 
 function install_ppa() {
-    if ${ELEVATE} apt-add-repository -y --no-update "${PPA}"; then
+    local AAR_PARAMS
+    AAR_PARAMS="-y"
+    if [ $(dpkg -S $(command -v apt-add-repository)|cut -d: -f1) == "software-properties-common" ] ; then
+        AAR_PARAMS+=" --no-update";
+    fi
+    if ${ELEVATE} apt-add-repository $AAR_PARAMS "${PPA}"; then
         update_apt
         if ! package_is_installed "${APP}"; then
             eula


### PR DESCRIPTION
Only use `--no-update`parameter for `apt-add-repository` if it comes from software-properties-common
hopefully a working and viable solution rather than checking and parsing parameters

works on Ubuntu Mate (with #366 in place)
also tested on

- [x] Mint
- [x] Pop
- [x] KDE neon
- [x] Debian
- [x] MX Linux xfce (no ppa support -  ID=debian)

closes #370
