### PR TITLE
Improve regexes of grep and sed

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -516,7 +516,7 @@ unload_etc_includes
 
 function deb_tixati() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(curl -s "https://www.tixati.com/download/linux.html" | grep "amd64.deb" | head -n1 | cut -d'"' -f2)"
+        URL="$(curl -s "https://www.tixati.com/download/linux.html" | grep "amd64\.deb\"" | head -n1 | cut -d'"' -f2)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Tixati"
@@ -607,7 +607,7 @@ function deb_code() {
 
 function deb_rstudio() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(curl -s "https://www.rstudio.com/products/rstudio/download/" | grep "amd64.deb" | grep -v "tar.gz" | head -n1 | cut -d'"' -f2)"
+        URL="$(curl -s "https://www.rstudio.com/products/rstudio/download/" | grep "amd64\.deb\"" | head -n1 | cut -d'"' -f2)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'-' -f2-3 | tr - +)"
     fi
     PRETTY_NAME="RStudio"
@@ -617,7 +617,7 @@ function deb_rstudio() {
 
 function deb_beersmith3() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(curl -s "https://beersmith.com/download-beersmith/" | grep "amd64.deb" | head -n1 | cut -d'"' -f2)"
+        URL="$(curl -s "https://beersmith.com/download-beersmith/" | grep "amd64\.deb\"" | head -n1 | cut -d'"' -f2)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'-' -f3 | cut -d'_' -f1)"
     fi
     PRETTY_NAME="BeerSmith"
@@ -642,7 +642,7 @@ function deb_ocenaudio() {
 function deb_github-desktop() {
     get_github_releases "https://api.github.com/repos/shiftkey/desktop/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | sed 's|release-||')"
     fi
     PRETTY_NAME="GitHub Desktop"
@@ -654,7 +654,7 @@ function deb_lsd() {
     ARCHS_SUPPORTED="amd64 arm64"
     get_github_releases "https://api.github.com/repos/Peltoche/lsd/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep -v musl | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v musl | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="LSDeluxe"
@@ -666,7 +666,7 @@ function deb_bat() {
     ARCHS_SUPPORTED="amd64 arm64 armhf"
     get_github_releases "https://api.github.com/repos/sharkdp/bat/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep -v musl | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v musl | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="bat"
@@ -678,7 +678,7 @@ function deb_git-delta() {
     ARCHS_SUPPORTED="amd64 arm64 armhf i386"
     get_github_releases "https://api.github.com/repos/dandavison/delta/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep -v musl | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v musl | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="git-delta"
@@ -690,7 +690,7 @@ function deb_fd() {
     ARCHS_SUPPORTED="amd64 arm64 armhf"
     get_github_releases "https://api.github.com/repos/sharkdp/fd/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep -v musl | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v musl | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="fd"
@@ -703,9 +703,9 @@ function deb_duf() {
     get_github_releases "https://api.github.com/repos/muesli/duf/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
         case "${HOST_ARCH}" in
-            armhf) URL=$(grep "browser_download_url.*armv7.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+            armhf) URL=$(grep "browser_download_url.*armv7\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
                    ;;
-            *)     URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+            *)     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         esac
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
@@ -717,7 +717,7 @@ function deb_duf() {
 function deb_zenith() {
     get_github_releases "https://api.github.com/repos/bvaisvil/zenith/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Zenith"
@@ -731,13 +731,13 @@ function deb_rclone() {
     if [ "${ACTION}" != "prettylist" ]; then
         case ${HOST_ARCH} in
             armhf)
-                URL=$(grep "browser_download_url.*arm-v7.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+                URL=$(grep "browser_download_url.*arm-v7\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
                 ;;
             i386)
-                URL=$(grep "browser_download_url.*386.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+                URL=$(grep "browser_download_url.*386\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
                 ;;
             *)
-                URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+                URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
                 ;;
         esac
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
@@ -753,16 +753,16 @@ function deb_hugo() {
     if [ "${ACTION}" != "prettylist" ]; then
         case ${HOST_ARCH} in
             amd64)
-                URL=$(grep "browser_download_url.*64bit.deb" "${CACHE_DIR}/${APP}.json" | grep -v extended | head -n1 | cut -d'"' -f4)
+                URL=$(grep "browser_download_url.*64bit\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v extended | head -n1 | cut -d'"' -f4)
                 ;;
             arm64)
-                URL=$(grep "browser_download_url.*ARM64.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+                URL=$(grep "browser_download_url.*ARM64\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
                 ;;
             armhf)
-                URL=$(grep "browser_download_url.*ARM.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+                URL=$(grep "browser_download_url.*ARM\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
                 ;;
             i386)
-                URL=$(grep "browser_download_url.*32bit.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+                URL=$(grep "browser_download_url.*32bit\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
                 ;;
         esac
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
@@ -777,8 +777,8 @@ function deb_simplenote() {
     get_github_releases "https://api.github.com/repos/Automattic/simplenote-electron/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
         case ${HOST_ARCH} in
-            amd64|i386) URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4);;
-            armhf) URL=$(grep "browser_download_url.*armhv7l.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4);;
+            amd64|i386) URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4);;
+            armhf) URL=$(grep "browser_download_url.*armhv7l\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4);;
         esac
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
@@ -790,7 +790,7 @@ function deb_simplenote() {
 function deb_peazip() {
     get_github_releases "https://api.github.com/repos/peazip/PeaZip/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep Qt5 | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep Qt5 | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="PeaZip"
@@ -801,7 +801,7 @@ function deb_peazip() {
 function deb_tribler() {
     get_github_releases "https://api.github.com/repos/Tribler/tribler/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*_all.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*_all\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Tribler"
@@ -812,7 +812,7 @@ function deb_tribler() {
 function deb_bottom() {
     get_github_releases "https://api.github.com/repos/ClementTsang/bottom/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="bottom"
@@ -940,7 +940,7 @@ function deb_docker-ce() {
 
 function deb_docker-desktop() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(curl -s "https://docs.docker.com/desktop/release-notes/" | grep amd64.deb | grep -Eo 'https://[^ >]+' | cut -d'?' -f1 | tr -d '"' | head -n1)"
+        URL="$(curl -s "https://docs.docker.com/desktop/release-notes/" | grep "amd64\.deb" | grep -Eo 'https://[^ >]+' | cut -d'?' -f1 | tr -d '"' | head -n1)"
         VERSION_PUBLISHED=$(echo "${URL}" | cut -d'-' -f3)
     fi
     PRETTY_NAME="Docker Desktop"
@@ -951,7 +951,7 @@ function deb_docker-desktop() {
 function deb_irccloud-desktop() {
     get_github_releases "https://api.github.com/repos/irccloud/irccloud-desktop/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="IRCCloud Desktop"
@@ -963,7 +963,7 @@ function deb_system-monitoring-center() {
     ARCHS_SUPPORTED="amd64 arm64 armhf"
     get_github_releases "https://api.github.com/repos/hakandundar34coding/system-monitoring-center/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*all.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*all\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f4)"
     fi
     PRETTY_NAME="System Monitoring Center"
@@ -975,7 +975,7 @@ function deb_minigalaxy() {
     ARCHS_SUPPORTED="amd64 arm64 armhf"
     get_github_releases "https://api.github.com/repos/sharkwouter/minigalaxy/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*all.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*all\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Minigalaxy"
@@ -986,7 +986,7 @@ function deb_minigalaxy() {
 function deb_com.github.tkashkin.gamehub() {
     get_github_releases "https://api.github.com/repos/tkashkin/GameHub/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep -v '\-dev' | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v '\-dev' | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | sed 's|-master||')"
     fi
     PRETTY_NAME="GameHub"
@@ -998,7 +998,7 @@ function deb_codium() {
     ARCHS_SUPPORTED="amd64 arm64 armhf"
     get_github_releases "https://api.github.com/repos/VSCodium/vscodium/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="VSCodium"
@@ -1009,7 +1009,7 @@ function deb_codium() {
 function deb_micro() {
     get_github_releases "https://api.github.com/repos/zyedidia/micro/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="micro"
@@ -1021,7 +1021,7 @@ function deb_ludo() {
     ARCHS_SUPPORTED="amd64 armhf"
     get_github_releases "https://api.github.com/repos/libretro/ludo/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep -v altui | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v altui | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Ludo"
@@ -1032,7 +1032,7 @@ function deb_ludo() {
 function deb_obsidian() {
     get_github_releases "https://api.github.com/repos/obsidianmd/obsidian-releases/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Obsidian"
@@ -1043,7 +1043,7 @@ function deb_obsidian() {
 function deb_mpdevil() {
     get_github_releases "https://api.github.com/repos/SoongNoonien/mpdevil/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="mpdevil"
@@ -1054,7 +1054,7 @@ function deb_mpdevil() {
 function deb_rambox() {
     get_github_releases "https://api.github.com/repos/ramboxapp/download/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*x64.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*x64\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Rambox"
@@ -1065,7 +1065,7 @@ function deb_rambox() {
 function deb_antimicrox() {
     get_github_releases "https://api.github.com/repos/AntiMicroX/antimicrox/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_CPU}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_CPU}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="AntiMicroX"
@@ -1076,7 +1076,7 @@ function deb_antimicrox() {
 function deb_franz() {
     get_github_releases "https://api.github.com/repos/meetfranz/franz/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Franz"
@@ -1087,7 +1087,7 @@ function deb_franz() {
 function deb_heroic() {
     get_github_releases "https://api.github.com/repos/Heroic-Games-Launcher/HeroicGamesLauncher/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep -v beta | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v beta | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Heroic Games Launcher"
@@ -1099,7 +1099,7 @@ function deb_deb-get() {
     ARCHS_SUPPORTED="amd64 arm64 armhf i386"
     get_github_releases "https://api.github.com/repos/wimpysworld/deb-get/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="deb-get"
@@ -1194,7 +1194,7 @@ function deb_pandoc() {
     ARCHS_SUPPORTED="amd64 arm64"
     get_github_releases "https://api.github.com/repos/jgm/pandoc/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'-' -f2)"
     fi
     PRETTY_NAME="Pandoc"
@@ -1249,7 +1249,7 @@ function deb_balena-etcher-electron() {
     ARCHS_SUPPORTED="amd64 i386"
     get_github_releases "https://api.github.com/repos/balena-io/etcher/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Etcher"
@@ -1260,7 +1260,7 @@ function deb_balena-etcher-electron() {
 function deb_caprine() {
     get_github_releases "https://api.github.com/repos/sindresorhus/caprine/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Caprine"
@@ -1270,8 +1270,8 @@ function deb_caprine() {
 
 function disable_sengi() {
     get_github_releases "https://api.github.com/repos/NicolasConstant/sengi/releases"
-    VERSION_PUBLISHED="$(grep "browser_download_url.*linux.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'/' -f8)"
-    URL=$(grep "browser_download_url.*linux.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(grep "browser_download_url.*linux\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'/' -f8)"
+    URL=$(grep "browser_download_url.*linux\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
     PRETTY_NAME="Sengi"
     WEBSITE="https://github.com/NicolasConstant/sengi"
     SUMMARY="Tweetdeck inspired Mastodon & Pleroma Multi-account Desktop Client."
@@ -1281,7 +1281,7 @@ function deb_figma-linux() {
     ARCHS_SUPPORTED="amd64 arm64"
     get_github_releases "https://api.github.com/repos/Figma-Linux/figma-linux/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Figma Linux"
@@ -1292,7 +1292,7 @@ function deb_figma-linux() {
 function deb_rpi-imager() {
     get_github_releases "https://api.github.com/repos/raspberrypi/rpi-imager/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Raspberry Pi Imager"
@@ -1303,7 +1303,7 @@ function deb_rpi-imager() {
 function deb_bitwarden() {
     get_github_releases "https://api.github.com/repos/bitwarden/clients/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d desktop-v-)"
     fi
     PRETTY_NAME="Bitwarden"
@@ -1314,7 +1314,7 @@ function deb_bitwarden() {
 function deb_insomnia() {
     get_github_releases "https://api.github.com/repos/Kong/insomnia/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep -v beta | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v beta | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'-' -f2 | sed s'|\.deb||')"
     fi
     PRETTY_NAME="Insomnia"
@@ -1325,7 +1325,7 @@ function deb_insomnia() {
 function deb_onlyoffice-desktopeditors() {
     get_github_releases "https://api.github.com/repos/ONLYOFFICE/DesktopEditors/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="ONLYOFFICE Desktop Editors"
@@ -1336,7 +1336,7 @@ function deb_onlyoffice-desktopeditors() {
 function deb_powershell() {
     get_github_releases "https://api.github.com/repos/PowerShell/PowerShell/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep -v -e preview -e lts | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v -e preview -e lts | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="PowerShell"
@@ -1347,7 +1347,7 @@ function deb_powershell() {
 function deb_mailspring() {
     get_github_releases "https://api.github.com/repos/Foundry376/Mailspring/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="Mailspring"
@@ -1359,7 +1359,7 @@ function deb_mattermost-desktop() {
     get_github_releases "https://api.github.com/repos/mattermost/desktop/releases"
     if [ "${ACTION}" != "prettylist" ]; then
         VERSION_PUBLISHED="$(grep "browser_download_url" "${CACHE_DIR}/${APP}.json" | grep -v -e rc | head -n1 | cut -d'"' -f4 | cut -d'/' -f8 | tr -d v)"
-        URL="$(curl https://github.com/mattermost/desktop/releases/ | grep "//releases.*${VERSION_PUBLISHED}.*${HOST_ARCH}.deb" | head -n 1 | cut -d\" -f 2)"
+        URL="$(curl https://github.com/mattermost/desktop/releases/ | grep "//releases.*${VERSION_PUBLISHED}.*${HOST_ARCH}\.deb\"" | head -n 1 | cut -d\" -f 2)"
     fi
     PRETTY_NAME="Mattermost Desktop"
     WEBSITE="https://mattermost.com/"
@@ -1369,7 +1369,7 @@ function deb_mattermost-desktop() {
 function deb_rocketchat() {
     get_github_releases "https://api.github.com/repos/RocketChat/Rocket.Chat.Electron/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="Rocketchat Desktop"
@@ -1380,7 +1380,7 @@ function deb_rocketchat() {
 function deb_whatsapp-for-linux() {
     get_github_releases "https://api.github.com/repos/eneshecan/whatsapp-for-linux/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="WhatsApp for Linux"
@@ -1391,7 +1391,7 @@ function deb_whatsapp-for-linux() {
 function deb_igdm() {
     get_github_releases "https://api.github.com/repos/igdmapps/igdm/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="IGdm Messenger"
@@ -1402,8 +1402,8 @@ function deb_igdm() {
 # Upstream login bug
 function disabled_igdm-pro() {
     get_github_releases "https://api.github.com/repos/igdmapps/igdm-pro-release/releases"
-    VERSION_PUBLISHED="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'_' -f2)"
-    URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+    VERSION_PUBLISHED="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4 | cut -d'_' -f2)"
+    URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
     PRETTY_NAME="IGdm Pro Messenger"
     WEBSITE="https://pro.igdm.me/"
     SUMMARY="Continue your Instagram direct messages from your phone to your desktop."
@@ -1412,7 +1412,7 @@ function disabled_igdm-pro() {
 function deb_whalebird() {
     get_github_releases "https://api.github.com/repos/h3poteto/whalebird-desktop/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*x64.deb" "${CACHE_DIR}/${APP}.json" | grep -v beta | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*x64\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v beta | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="Whalebird"
@@ -1424,7 +1424,7 @@ function deb_syft() {
     ARCHS_SUPPORTED="amd64 arm64"
     get_github_releases "https://api.github.com/repos/anchore/syft/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Syft"
@@ -1436,7 +1436,7 @@ function deb_grype() {
     ARCHS_SUPPORTED="amd64 arm64"
     get_github_releases "https://api.github.com/repos/anchore/grype/releases"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Grype"
@@ -1450,16 +1450,16 @@ function deb_trivy() {
     if [ "${ACTION}" != "prettylist" ]; then
         case ${HOST_ARCH} in
             amd64)
-                URL="$(grep "browser_download_url.*64bit.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+                URL="$(grep "browser_download_url.*64bit\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
                 ;;
             arm64)
-                URL="$(grep "browser_download_url.*ARM64.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+                URL="$(grep "browser_download_url.*ARM64\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
                 ;;
             armhf)
-                URL="$(grep "browser_download_url.*ARM.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+                URL="$(grep "browser_download_url.*ARM\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
                 ;;
             i386)
-                URL="$(grep "browser_download_url.*32bit.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+                URL="$(grep "browser_download_url.*32bit\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
                 ;;
         esac
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
@@ -1534,7 +1534,7 @@ function deb_webex() {
 
 function deb_deadbeef() {
     if [ "${ACTION}" != "prettylist" ]; then
-        local REDIR_URL="$(curl -s "https://deadbeef.sourceforge.io/download.html" | grep amd64.deb | cut -d'"' -f2)"
+        local REDIR_URL="$(curl -s "https://deadbeef.sourceforge.io/download.html" | grep "amd64\.deb\"" | cut -d'"' -f2)"
         URL=$(unroll_url "${REDIR_URL}")
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
@@ -1546,7 +1546,7 @@ function deb_deadbeef() {
 function deb_dropbox() {
     ARCHS_SUPPORTED="amd64 i386"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="https://linux.dropbox.com/packages/ubuntu/$(curl -s "https://linux.dropbox.com/packages/ubuntu/" | grep "${HOST_ARCH}.deb" | sed -e 's/<[^>]*>//g' | grep -v nautilus | cut -d' ' -f1 | tail -n1)"
+        URL="https://linux.dropbox.com/packages/ubuntu/$(curl -s "https://linux.dropbox.com/packages/ubuntu/" | grep "${HOST_ARCH}\.deb" | sed -e 's/<[^>]*>//g' | grep -v nautilus | cut -d' ' -f1 | tail -n1)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Dropbox"
@@ -1578,7 +1578,7 @@ function deb_surfshark() {
 
 function deb_shutter-encoder() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="https://www.shutterencoder.com/$(curl -s "https://www.shutterencoder.com/en/thanks.html" | grep 64bits.deb | cut -d'"' -f2 | sed 's|../||')"
+        URL="https://www.shutterencoder.com/$(curl -s "https://www.shutterencoder.com/en/thanks.html" | grep "64bits\.deb\"" | cut -d'"' -f2 | sed 's|../||')"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d' ' -f3)"
     fi
     PRETTY_NAME="shutter-encoder"
@@ -1677,7 +1677,7 @@ function deb_exodus() {
 function deb_jabref() {
     get_github_releases "https://api.github.com/repos/jabref/jabref/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="JabRef"
@@ -1688,7 +1688,7 @@ function deb_jabref() {
 function deb_draw.io() {
     get_github_releases "https://api.github.com/repos/jgraph/drawio-desktop/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="draw.io"
@@ -1700,7 +1700,7 @@ function deb_gh() {
     ARCHS_SUPPORTED="amd64 arm64"
     get_github_releases "https://api.github.com/repos/cli/cli/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="GitHub CLI"
@@ -1771,7 +1771,7 @@ function deb_telegraf() {
 function deb_brisqi() {
     get_github_releases "https://api.github.com/repos/Brisqi/releases/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Brisqi"
@@ -1781,7 +1781,7 @@ function deb_brisqi() {
 
 function deb_teamviewer() {
     if [ "${ACTION}" != "prettylist" ]; then
-        VERSION_PUBLISHED="$(curl -s 'https://www.teamviewer.com/en/download/linux/' | grep -C 5 'Ubuntu, Debian' | grep '\*.deb package' | cut -d ' ' -f3 | sed 's/\([0-9\.]*\).*$/\1/')"
+        VERSION_PUBLISHED="$(curl -s 'https://www.teamviewer.com/en/download/linux/' | grep -C 5 'Ubuntu, Debian' | grep '\*\.deb package' | cut -d ' ' -f3 | sed 's/\([0-9\.]*\).*$/\1/')"
     fi
     URL="https://download.teamviewer.com/download/linux/teamviewer_amd64.deb"
     PRETTY_NAME="TeamViewer"
@@ -1898,7 +1898,7 @@ function deb_hyper() {
     ARCHS_SUPPORTED="amd64 arm64"
     get_github_releases "https://api.github.com/repos/vercel/hyper/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep -v canary | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v canary | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Hyper"
@@ -1909,7 +1909,7 @@ function deb_hyper() {
 function deb_p3x-onenote() {
     get_github_releases "https://api.github.com/repos/patrikx3/onenote/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="P3X OneNote"
@@ -1920,7 +1920,7 @@ function deb_p3x-onenote() {
 function deb_ms-office-electron() {
     get_github_releases "https://api.github.com/repos/agam778/MS-Office-Electron/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Office 365"
@@ -1931,7 +1931,7 @@ function deb_ms-office-electron() {
 function deb_geforcenow-electron() {
     get_github_releases "https://api.github.com/repos/hmlendea/gfn-electron/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="GeForce NOW"
@@ -1943,7 +1943,7 @@ function deb_zettlr() {
     ARCHS_SUPPORTED="amd64 arm64"
     get_github_releases "https://api.github.com/repos/Zettlr/Zettlr/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Zettlr"
@@ -1954,7 +1954,7 @@ function deb_zettlr() {
 function deb_ksnip() {
     get_github_releases "https://api.github.com/repos/ksnip/ksnip/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="ksnip"
@@ -1965,7 +1965,7 @@ function deb_ksnip() {
 function deb_tidal-hifi() {
     get_github_releases "https://api.github.com/repos/Mastermindzh/tidal-hifi/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Tidal-hifi"
@@ -1976,7 +1976,7 @@ function deb_tidal-hifi() {
 function deb_dustracing2d() {
     get_github_releases "https://api.github.com/repos/juzzlin/DustRacing2D/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | grep "18.04" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep "18\.04" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="DustRacing2D"
@@ -1988,7 +1988,7 @@ function deb_obs-cli() {
     ARCHS_SUPPORTED="amd64 arm64 armhf"
     get_github_releases "https://api.github.com/repos/muesli/obs-cli/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="OBS-cli"
@@ -1999,7 +1999,7 @@ function deb_obs-cli() {
 function deb_google-chat-electron() {
     get_github_releases "https://api.github.com/repos/ankurk91/google-chat-electron/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi
     PRETTY_NAME="Google Chat"
@@ -2010,7 +2010,7 @@ function deb_google-chat-electron() {
 function deb_expressvpn() {
     ARCHS_SUPPORTED="amd64 i386 armhf"
     if [ "${ACTION}" != "prettylist" ]; then
-        VERSION_PUBLISHED="$(curl -s "https://www.expressvpn.com/latest#linux" | grep -o 'value="https://www.expressvpn.works/clients/linux/expressvpn_.*'${HOST_ARCH}'.deb"' | cut -d"_" -f2)"
+        VERSION_PUBLISHED="$(curl -s "https://www.expressvpn.com/latest#linux" | grep -o 'value="https://www\.expressvpn\.works/clients/linux/expressvpn_.*'${HOST_ARCH}'\.deb"' | cut -d"_" -f2)"
         URL="https://www.expressvpn.works/clients/linux/expressvpn_${VERSION_PUBLISHED}_${HOST_ARCH}.deb"
     fi
     PRETTY_NAME="Expressvpn"
@@ -2021,7 +2021,7 @@ function deb_expressvpn() {
 function deb_blockbench() {
     get_github_releases "https://api.github.com/repos/JannisX11/blockbench/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Blockbench"
@@ -2039,7 +2039,7 @@ function deb_copyq() {
 function deb_dbeaver-ce() {
     ARCHS_SUPPORTED="amd64 i386"
     if [ "${ACTION}" != "prettylist" ]; then
-        VERSION_PUBLISHED="$(curl -s https://dbeaver.io/debs/dbeaver-ce/ | grep -o '"dbeaver-ce_.*'${HOST_ARCH}'.deb"' | sort --version-sort | tail -n1 | cut -d"_" -f2)"
+        VERSION_PUBLISHED="$(curl -s https://dbeaver.io/debs/dbeaver-ce/ | grep -o '"dbeaver-ce_.*'${HOST_ARCH}'\.deb"' | sort --version-sort | tail -n1 | cut -d"_" -f2)"
         URL="https://dbeaver.io/debs/dbeaver-ce/dbeaver-ce_${VERSION_PUBLISHED}_${HOST_ARCH}.deb"
     fi
     PRETTY_NAME="DBeaver"
@@ -2066,9 +2066,9 @@ function deb_rustdesk() {
     get_github_releases "https://api.github.com/repos/rustdesk/rustdesk/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
         case "${HOST_ARCH}" in
-            amd64) URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep -Ev "$(echo ${ARCHS_SUPPORTED} | tr " " "|")" | head -n1 | cut -d'"' -f4)"
+            amd64) URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -Ev "$(echo ${ARCHS_SUPPORTED} | tr " " "|")" | head -n1 | cut -d'"' -f4)"
             ;;
-            *) URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+            *) URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
             ;;
         esac
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
@@ -2081,7 +2081,7 @@ function deb_rustdesk() {
 function deb_picocrypt() {
     get_github_releases "https://api.github.com/repos/HACKERALERT/Picocrypt/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="Picocrypt"
@@ -2099,7 +2099,7 @@ function deb_ulauncher() {
 function deb_battery-monitor() {
     get_github_releases "https://api.github.com/repos/hsbasu/battery-monitor/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="Battery Monitor"
@@ -2110,7 +2110,7 @@ function deb_battery-monitor() {
 function deb_android-messages-desktop() {
     get_github_releases "https://api.github.com/repos/OrangeDrangon/android-messages-desktop/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="android-messages-desktop"
@@ -2128,7 +2128,7 @@ function deb_yq() {
 function deb_youtube-music() {
     get_github_releases "https://api.github.com/repos/th-ch/youtube-music/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="youtube-music"
@@ -2140,7 +2140,7 @@ function deb_minikube() {
     ARCHS_SUPPORTED="amd64 arm64 armhf ppc64el s390x"
     get_github_releases "https://api.github.com/repos/kubernetes/minikube/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*minikube_.*_${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*minikube_.*_${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="minikube"
@@ -2177,8 +2177,8 @@ function deb_mergerfs() {
     ARCHS_SUPPORTED="amd64 arm64 armhf"
     get_github_releases "https://api.github.com/repos/trapexit/mergerfs/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        CODENAMES_SUPPORTED=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep "${HOST_ARCH}" | cut -d'-' -f2 | cut -d'_' -f1 | tr '\n' ' ')
-        URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep "${UPSTREAM_CODENAME}_${HOST_ARCH}" | cut -d'"' -f4)"
+        CODENAMES_SUPPORTED=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | grep "${HOST_ARCH}" | cut -d'-' -f2 | cut -d'_' -f1 | tr '\n' ' ')
+        URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | grep "${UPSTREAM_CODENAME}_${HOST_ARCH}" | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
     fi
     PRETTY_NAME="mergerfs"
@@ -2189,7 +2189,7 @@ function deb_mergerfs() {
 function deb_openaudible() {
     get_github_releases "https://api.github.com/repos/openaudible/openaudible/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*x86_64.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*x86_64\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         VERSION_PUBLISHED="$(echo ${URL} | cut -d'_' -f2)"
     fi
     PRETTY_NAME="OpenAudible"
@@ -2199,7 +2199,7 @@ function deb_openaudible() {
 
 function deb_deltachat-desktop() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(curl -s "$(unroll_url https://delta.chat/download)" | grep ".deb" | cut -d "\"" -f 2)"
+        URL="$(curl -s "$(unroll_url https://delta.chat/download)" | grep "\.deb\"" | cut -d "\"" -f 2)"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d "/" -f 5 | tr -d v)"
     fi
     PRETTY_NAME="Delta Chat"
@@ -2220,7 +2220,7 @@ function deb_bitwig-studio() {
 function deb_sleek() {
     get_github_releases "https://api.github.com/repos/ransome1/sleek/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Sleek"
@@ -2276,7 +2276,7 @@ function deb_gpu-viewer() {
 
 function deb_stremio() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(curl -s https://www.stremio.com/downloads | grep -o "dl-linux-four-deb.*amd64.deb" | cut -d "\"" -f 3)"
+        URL="$(curl -s https://www.stremio.com/downloads | grep -o "dl-linux-four-deb.*amd64\.deb\"" | cut -d "\"" -f 3)"
         VERSION_PUBLISHED=""$(echo "${URL}" | cut -d "_" -f 2)""
     fi
     PRETTY_NAME="Stremio"
@@ -2288,7 +2288,7 @@ function deb_standard-notes() {
     ARCHS_SUPPORTED="amd64 i386 arm64"
     get_github_releases "https://api.github.com/repos/standardnotes/app/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(grep "browser_download_url.*${HOST_ARCH}.deb" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
         local VERSION_TMP="${URL##*/standard-notes-}"
         VERSION_PUBLISHED="${VERSION_TMP%%-linux*}"
     fi
@@ -2299,7 +2299,7 @@ function deb_standard-notes() {
 
 function deb_crossover() {
     if [ "${ACTION}" != "prettylist" ]; then
-        local VERSION_NAME="$(curl -s "https://media.codeweavers.com/pub/crossover/cxlinux/demo/?V=1;O=D;F=0;P=crossover_*.deb"| grep \.deb | head -n1 | cut -d"\"" -f 2)"
+        local VERSION_NAME="$(curl -s "https://media.codeweavers.com/pub/crossover/cxlinux/demo/?V=1;O=D;F=0;P=crossover_*.deb"| grep "\.deb\"" | head -n1 | cut -d"\"" -f 2)"
         VERSION_PUBLISHED="${VERSION_NAME:10:-4}"
         URL="https://media.codeweavers.com/pub/crossover/cxlinux/demo/${VERSION_NAME}"
     fi
@@ -2311,7 +2311,7 @@ function deb_crossover() {
 function deb_motrix() {
     get_github_releases "https://api.github.com/repos/agalwood/Motrix/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Motrix"
@@ -2338,7 +2338,7 @@ function deb_blanket() {
 
 function deb_bluejeans-v2() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(curl -s "$(unroll_url https://www.bluejeans.com/downloads)" | grep "BlueJeans_.*\.deb" | head -n1 | cut -d"\"" -f 2)"
+        URL="$(curl -s "$(unroll_url https://www.bluejeans.com/downloads)" | grep "BlueJeans_.*\.deb\"" | head -n1 | cut -d"\"" -f 2)"
         local VERSION_TMP="${URL##*/BlueJeans_}"
         VERSION_PUBLISHED="${VERSION_TMP%%.deb}"
     fi
@@ -2362,7 +2362,7 @@ function deb_flameshot() {
 function deb_notable() {
     get_github_releases "https://api.github.com/repos/notable/notable/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Notable"
@@ -2373,7 +2373,7 @@ function deb_notable() {
 function deb_protonmail-bridge() {
     get_github_releases "https://api.github.com/repos/ProtonMail/proton-bridge/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Proton Mail Bridge"
@@ -2405,7 +2405,7 @@ function deb_appimagelauncher() {
 function deb_mullvad() {
     get_github_releases "https://api.github.com/repos/mullvad/mullvadvpn-app/releases/latest"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | cut -d'"' -f4)
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
     fi
     PRETTY_NAME="Mullvad VPN Client"

--- a/deb-get
+++ b/deb-get
@@ -1578,7 +1578,7 @@ function deb_surfshark() {
 
 function deb_shutter-encoder() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="https://www.shutterencoder.com/$(curl -s "https://www.shutterencoder.com/en/thanks.html" | grep "64bits\.deb\"" | cut -d'"' -f2 | sed 's|../||')"
+        URL="https://www.shutterencoder.com/$(curl -s "https://www.shutterencoder.com/en/thanks.html" | grep "64bits\.deb\"" | cut -d'"' -f2 | sed 's|\.\./||')"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d' ' -f3)"
     fi
     PRETTY_NAME="shutter-encoder"
@@ -1666,7 +1666,7 @@ function deb_azuredatastudio() {
 
 function deb_exodus() {
     if [ "${ACTION}" != "prettylist" ]; then
-        VERSION_PUBLISHED="$(curl -s https://www.exodus.com/download/|sed "s/.*https:\/\/downloads.exodus.com\/releases\/hashes-exodus-//"|sed "s/\.txt.*//")"
+        VERSION_PUBLISHED="$(curl -s https://www.exodus.com/download/|sed "s|.*https://downloads\.exodus\.com/releases/hashes-exodus-||"|sed "s/\.txt.*//")"
         URL="https://downloads.exodus.com/releases/exodus-linux-x64-${VERSION_PUBLISHED}.deb"
     fi
     PRETTY_NAME="Exodus"


### PR DESCRIPTION
Some characters were not properly escaped, such as `.`. This also adds an `"` at the end of the regexes when grepping `*.deb` URLs. Fixes #406.