### PR TITLE
Grep the URL of the latest version of bitwig-studio from the download website

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2209,7 +2209,7 @@ function deb_deltachat-desktop() {
 
 function deb_bitwig-studio() {
     if [ "${ACTION}" != "prettylist" ]; then
-        URL="$(unroll_url "https://www.bitwig.com/dl/?id=481&os=installer_linux")"
+        URL="$(unroll_url "$(curl -s "https://www.bitwig.com/download/" | grep -o "https://www\.bitwig\.com/dl/?id=[^&]*&amp;os=installer_linux")")"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d "/" -f 4)"
     fi
     PRETTY_NAME="BitWig Studio"


### PR DESCRIPTION
Fixes https://github.com/wimpysworld/deb-get/issues/253#issuecomment-1209704943.