### PR TITLE
fix mergerfs saying there's an update when there's not.

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2179,7 +2179,7 @@ function deb_mergerfs() {
     if [ "${ACTION}" != "prettylist" ]; then
         CODENAMES_SUPPORTED=$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep "${HOST_ARCH}" | cut -d'-' -f2 | cut -d'_' -f1 | tr '\n' ' ')
         URL="$(grep "browser_download_url.*.deb" "${CACHE_DIR}/${APP}.json" | grep "${UPSTREAM_CODENAME}_${HOST_ARCH}" | cut -d'"' -f4)"
-        VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
+        VERSION_PUBLISHED="$(echo "${URL}" | cut -d _ -f2 | sed -E "s/([0-9])\\.([a-z])/\1~\2/")"
     fi
     PRETTY_NAME="mergerfs"
     WEBSITE="https://github.com/trapexit/mergerfs"


### PR DESCRIPTION
Fixed the VERSION_PUBLISHED of mergerfs to match the format of VERSION_INSTALLED so it's not constantly saying there's an update when there's not.