### PR TITLE
Use github PAT to get higher github rate-limit

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -5,6 +5,11 @@ PACKAGE_INSTALLATION_COUNT=0
 
 readonly VERSION="0.3.4"
 
+# set a github auth token (e.g a PAT ) in DEBGET_TOKEN to get a bigger rate limit
+if [ -n ${DEBGET_TOKEN} ]; then
+ export HEADERAUTH="--header \"Authorization: token ${DEBGET_TOKEN}\""
+fi
+
 function usage() {
 cat <<HELP
 
@@ -117,7 +122,7 @@ function get_github_releases() {
     if [ "${ACTION}" == "install" ] || [ "${ACTION}" == "update" ]; then
         fancy_message info "Updating ${CACHE_DIR}/${APP}.json"
         if [ ! -e "${CACHE_DIR}/${APP}.json" ] || test "$(find "${CACHE_DIR}/${APP}.json" -mmin +60)"; then
-            if ! ${ELEVATE} wget -q "${1}" -O "${CACHE_DIR}/${APP}.json"; then
+            if ! ${ELEVATE} wget "${HEADERAUTH}" q "${1}" -O "${CACHE_DIR}/${APP}.json"; then
                 fancy_message warn "Updating ${CACHE_DIR}/${APP}.json failed. Deleting it."
                 ${ELEVATE} rm "${CACHE_DIR}/${APP}.json" 2>/dev/null
             fi


### PR DESCRIPTION
Goes from 60/hour to 5000/hour for authenticated sessions.
This makes it possible to run more than a couple of tests per hour for contributors with a collection of `deb-get`-"installed-from-github"  apps :raised_hands: 

Aaarg - this worked ONCE so I pushed and made a PR, at which point it ceased to work even after finding and fixing the typo!
