### PR TITLE
Use PAT to get higher github rate-limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,21 +235,23 @@ cog.out(pretty_list)
 | [<img src=".github/github.png" align="top" width="20" />](https://github.com/trapexit/mergerfs) | `mergerfs` | <i>A featureful union filesystem.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://micro-editor.github.io/) | `micro` | <i>A modern and intuitive terminal-based text editor.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://www.microsoft.com/edge) | `microsoft-edge-stable` | <i>Fast and secure browser that helps you protect your data and save time and money.</i> |
-| [<img src=".github/github.png" align="top" width="20" />](https://minbrowser.org/) | `min` | <i>A fast, minimal browser</i> |
+| [<img src=".github/github.png" align="top" width="20" />](https://minbrowser.org) | `min` | <i>A fast, minimal browser.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://sharkwouter.github.io/minigalaxy/) | `minigalaxy` | <i>A simple GOG client for Linux.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://minikube.sigs.k8s.io/) | `minikube` | <i>minikube quickly sets up a local Kubernetes cluster on macOS, Linux, and Windows.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://motrix.app/) | `motrix` | <i>A full-featured download manager.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://github.com/SoongNoonien/mpdevil) | `mpdevil` | <i>A simple music browser for MPD.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://agam778.github.io/MS-Office-Electron/) | `ms-office-electron` | <i>A Microsoft Office Online Desktop Client made with Electron.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://mullvad.net/) | `mullvad-vpn` | <i>VPN Service based in Sweden that does not collect user data.</i> |
+| [<img src=".github/debian.png" align="top" width="20" />](https://gitlab.com/volian/nala) | `nala` | <i>Commandline frontend for the APT package manager for Ubuntu 22.04 / Debian Sid and newer.</i> |
+| [<img src=".github/debian.png" align="top" width="20" />](https://gitlab.com/volian/nala) | `nala-legacy` | <i>Commandline frontend for the APT package manager for Ubuntu 21.04 / Debian Stable and older.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://neo4j.com/) | `neo4j` | <i>The Graph Data Platform for Today's Intelligent Applications.</i> |
 | [<img src=".github/launchpad.png" align="top" width="20" />](https://nextcloud.com/) | `nextcloud-desktop` | <i>The self-hosted productivity platform that keeps you in control.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://www.nomadproject.io/) | `nomad` | <i>Orchestration tool for deploying and managing applications.</i> |
 | [<img src=".github/direct.png" align="top" width="20" />](https://nordvpn.com/) | `nordvpn` | <i>VPN service for speed and security.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://notable.app/) | `notable` | <i>The Markdown-based note-taking app that doesn't suck.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://github.com/muesli/obs-cli) | `obs-cli` | <i>OBS-cli is a command-line remote control for OBS.</i> |
-| [<img src=".github/launchpad.png" align="top" width="20" />](https://obsproject.com/) | `obs-studio` | <i>Free and open source software for video recording and live streaming.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://obsidian.md/) | `obsidian` | <i>A powerful knowledge base on top of a local folder of plain text Markdown files.</i> |
+| [<img src=".github/launchpad.png" align="top" width="20" />](https://obsproject.com/) | `obs-studio` | <i>Free and open source software for video recording and live streaming.</i> |
 | [<img src=".github/direct.png" align="top" width="20" />](https://www.ocenaudio.com/) | `ocenaudio` | <i>Easy, fast and powerful audio editor.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://www.onlyoffice.com/en/desktop.aspx) | `onlyoffice-desktopeditors` | <i>Free desktop office suite for document editing and collaboration.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://github.com/openaudible/openaudible) | `openaudible` | <i>A cross-platform desktop application for downloading and managing your Audible audiobooks.</i> |
@@ -268,8 +270,8 @@ cog.out(pretty_list)
 | [<img src=".github/github.png" align="top" width="20" />](https://docs.microsoft.com/powershell/) | `powershell` | <i>Cross-platform automation and configuration tool/framework and optimized for dealing with structured data.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://proton.me/mail/bridge) | `protonmail-bridge` | <i>Proton Mail Bridge adds end-to-end encryption to popular email apps, including Outlook, Thunderbird, and Apple Mail.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://protonvpn.com/) | `protonvpn` | <i>High-speed Swiss VPN that safeguards your privacy.</i> |
-| [<img src=".github/launchpad.png" align="top" width="20" />](https://www.qownnotes.org) | `qownnotes` | <i>Free open source plain-text file markdown note-taking with Nextcloud / ownCloud integration.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://maplemedia.io/apps/) | `pulse-sms` | <i>A desktop client for Pulse SMS</i> |
+| [<img src=".github/launchpad.png" align="top" width="20" />](https://www.qownnotes.org) | `qownnotes` | <i>Free open source plain-text file markdown note-taking with Nextcloud / ownCloud integration.</i> |
 | [<img src=".github/launchpad.png" align="top" width="20" />](https://github.com/quickemu-project/quickemu) | `quickemu` | <i>Quickly create and run optimised Windows, macOS and Linux desktop virtual machines.</i> |
 | [<img src=".github/launchpad.png" align="top" width="20" />](https://github.com/quickemu-project/quickgui) | `quickgui` | <i>A Flutter frontend for Quickemu.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://rambox.app/) | `rambox` | <i>Workspace simplifier.</i> |
@@ -355,6 +357,25 @@ For `.deb` packages that are only available via GitHub Releases
 <img src=".github/github.png" align="top" width="20" /> or direct download
 <img src=".github/direct.png" align="top" width="20" />, then those packages
 can only be updated/upgrade by using `deb-get update` and `deb-get upgrade`.
+
+#### GitHub API Rate Limits
+
+`deb-get` uses the [GitHub REST API](https://docs.github.com/en/rest) for some functionality when applications are provided via  GitHub Releases
+<img src=".github/github.png" align="top" width="20" />
+and for unauthenticated interactions this API is [rate-limited](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) to 60 calls per hour per source (IP Address). This is vital for keeping the API responsive and available to all users, but can be inconvenient if you have a lot of GitHub releases being handled by `deb-get` (or need to update several times in a short period to test your [contribution](CONTRIBUTING.md)) and will result in, for example, temporary failures to be able to upgrade or install applications via  GitHub Releases
+<img src=".github/github.png" align="top" width="20" />.
+
+If you have a GitHub account you can authenticate your GitHub API usage to increase your rate-limit to 5000 requests per hour per authenticated user.  To do this you will need to use a [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). Once you have created a token within GitHub (or identified an appropriate exiting token) you should insert it into an environment variable (`DEBGET_TOKEN`) for `deb-get` to pick up and use to authenticate to the GitHub API.
+
+e.g.:
+
+```
+export DEBGET_TOKEN=<my-secret-token>
+deb-get update
+deb-get upgrade
+```
+
+
 
 ## Adding Software
 

--- a/deb-get
+++ b/deb-get
@@ -5,6 +5,15 @@ PACKAGE_INSTALLATION_COUNT=0
 
 readonly VERSION="0.3.4"
 
+# set a github auth token (e.g a PAT ) in DEBGET_TOKEN to get a bigger rate limit
+if [[ ! -z ${DEBGET_TOKEN} ]]; then
+    export HEADERAUTH="\"Authorization: token ${DEBGET_TOKEN}\""
+    export HEADERPARAM="--header"
+else
+    unset HEADERAUTH
+    unset HEADERPARAM
+fi
+
 function usage() {
 cat <<HELP
 
@@ -117,7 +126,8 @@ function get_github_releases() {
     if [ "${ACTION}" == "install" ] || [ "${ACTION}" == "update" ]; then
         fancy_message info "Updating ${CACHE_DIR}/${APP}.json"
         if [ ! -e "${CACHE_DIR}/${APP}.json" ] || test "$(find "${CACHE_DIR}/${APP}.json" -mmin +60)"; then
-            if ! ${ELEVATE} wget -q "${1}" -O "${CACHE_DIR}/${APP}.json"; then
+            wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q "${1}" -O "${CACHE_DIR}/${APP}.json")
+            if [ ! ${ELEVATE} "${wgetcmdarray[@]}" ]; then
                 fancy_message warn "Updating ${CACHE_DIR}/${APP}.json failed. Deleting it."
                 ${ELEVATE} rm "${CACHE_DIR}/${APP}.json" 2>/dev/null
             fi

--- a/deb-get
+++ b/deb-get
@@ -126,11 +126,8 @@ function get_github_releases() {
     if [ "${ACTION}" == "install" ] || [ "${ACTION}" == "update" ]; then
         fancy_message info "Updating ${CACHE_DIR}/${APP}.json"
         if [ ! -e "${CACHE_DIR}/${APP}.json" ] || test "$(find "${CACHE_DIR}/${APP}.json" -mmin +60)"; then
-            wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q "${1}" -O "${CACHE_DIR}/${APP}.json")
-            if [ ! ${ELEVATE} "${wgetcmdarray[@]}" ]; then
-                fancy_message warn "Updating ${CACHE_DIR}/${APP}.json failed. Deleting it."
-                ${ELEVATE} rm "${CACHE_DIR}/${APP}.json" 2>/dev/null
-            fi
+            wgetcmdarray=(${ELEVATE} wget  "${HEADERPARAM}" "${HEADERAUTH}" -q "${1}" -O "${CACHE_DIR}/${APP}.json")
+            echo "${wgetcmdarray[@]}" | bash -  || ( fancy_message warn "Updating ${CACHE_DIR}/${APP}.json failed. Deleting it." ; ${ELEVATE} rm "${CACHE_DIR}/${APP}.json" 2>/dev/null )
             if [ -f "${CACHE_DIR}/${APP}.json" ] && grep "API rate limit exceeded" "${CACHE_DIR}/${APP}.json"; then
                 fancy_message warn "Updating ${CACHE_DIR}/${APP}.json exceed GitHub API limits. Deleting it."
                 ${ELEVATE} rm "${CACHE_DIR}/${APP}.json" 2>/dev/null


### PR DESCRIPTION
Goes from 60/hour to 5000/hour for authenticated sessions.

This should hopefully avoid serious `deb-get`ters (and those testing repeatedly :raised_hands: ) from running into rate-limiting issues too early and often.