### PR TITLE
remove Waydroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,6 @@ cog.out(pretty_list)
 | [<img src=".github/debian.png" align="top" width="20" />](https://vivaldi.com/) | `vivaldi-stable` | <i>The most feature-packaged, customisable browser.</i> |
 | [<img src=".github/direct.png" align="top" width="20" />](https://www.hamrick.com/) | `vuescan` | <i>Scanner Software that supports over 6500 scanners.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://wavebox.io/) | `wavebox` | <i>Rethink the Web. Productivity Browser.</i> |
-| [<img src=".github/debian.png" align="top" width="20" />](https://waydro.id/) | `waydroid` | <i>A container-based approach to boot a full Android system on a regular GNU/Linux system like Ubuntu.</i> |
 | [<img src=".github/direct.png" align="top" width="20" />](https://www.webex.com/) | `webex` | <i>Video Conferencing, Cloud Calling and Screen Sharing.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://weechat.org/) | `weechat` | <i>The extensible chat client.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://whalebird.social/) | `whalebird` | <i>A Mastodon, Pleroma, and Misskey client for desktop application.</i> |

--- a/deb-get
+++ b/deb-get
@@ -1116,15 +1116,6 @@ function deb_skypeforlinux() {
     SUMMARY="Stay connected with free video calls worldwide."
 }
 
-function deb_waydroid() {
-    GPG_KEY_URL="https://repo.waydro.id/waydroid.gpg"
-    APT_LIST_NAME="waydroid"
-    APT_REPO_URL="deb [signed-by=/usr/share/keyrings/${APT_LIST_NAME}-archive-keyring.gpg] https://repo.waydro.id ${UPSTREAM_CODENAME} main"
-    PRETTY_NAME="WayDroid"
-    WEBSITE="https://waydro.id/"
-    SUMMARY="A container-based approach to boot a full Android system on a regular GNU/Linux system like Ubuntu."
-}
-
 function deb_wavebox() {
     APT_KEY_URL="https://wavebox.pro/dl/client/repo/archive.key"
     APT_LIST_NAME="wavebox-stable"


### PR DESCRIPTION
[the waydroid package maintainer](https://github.com/waydroid/docs/commit/f186373d1d2a8b5d7e3cb5f008269bee18fde7fc) decided to [no longer use ubuntu and debian codenames](https://github.com/wimpysworld/deb-get/pull/320#issuecomment-1218076734).

I have no idea if this is solvable, but as this will no longer work correctly, might as well remove it until or unless this is or can be solved