### PR TITLE
[minor] no error if cache already empty

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2637,8 +2637,8 @@ case "${ACTION}" in
         ls -lh "${CACHE_DIR}/";;
     clean)
         elevate_privs
-        ${ELEVATE} rm -v "${CACHE_DIR}"/*.deb
-        ${ELEVATE} rm -v "${CACHE_DIR}"/*.json;;
+        ${ELEVATE} rm -fv "${CACHE_DIR}"/*.deb
+        ${ELEVATE} rm -fv "${CACHE_DIR}"/*.json;;
     show)
         for APP in "${@,,}"; do
             validate_deb "${APP}"


### PR DESCRIPTION
if the cache is empty, it gives an error that it can't rm the files....
Adding -f to silence it.