### PR TITLE
Fix REDIR_URL for deadbeef

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1561,7 +1561,7 @@ function deb_webex() {
 
 function deb_deadbeef() {
     if [ "${ACTION}" != "prettylist" ]; then
-        local REDIR_URL="$(curl -s "https://deadbeef.sourceforge.io/download.html" | grep "amd64\.deb\"" | cut -d'"' -f2)"
+        local REDIR_URL="$(curl -s "https://sourceforge.net/projects/deadbeef/rss?path=/travis/linux" | grep link | grep "\.deb" | grep -v beta | grep -v devel | head -n1 | cut -d '>' -f2 | cut -d '<' -f1)"
         URL=$(unroll_url "${REDIR_URL}")
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
     fi


### PR DESCRIPTION
The original link wasn't finding anything for me. This uses the travis CI RSS feed, which contains the links.