### PR TITLE
Kali support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,9 @@ To update `README.md`, first install [cog](https://pypi.org/project/cogapp):
 ```bash
 sudo pip3 install cogapp
 ```
+
+Ensure any local Custom User Includes are removed from `/etc/deb-get.d/` (They can be replaced after the README.md is re-processed)
+
 Then run:
 ```bash
 cog -r README.md

--- a/deb-get
+++ b/deb-get
@@ -2577,7 +2577,7 @@ case "${OS_ID}" in
   Pop) OS_ID_PRETTY="Pop!_OS";;
   Ubuntu) OS_ID_PRETTY="Ubuntu";;
   Zorin) OS_ID_PRETTY="Zorin OS";;
-  #Kali) OS_ID_PRETTY="Kali GNU/Linux Rolling"
+  Kali) OS_ID_PRETTY="Kali GNU/Linux Rolling";;
   *) fancy_message fatal "${OS_ID} is not supported.";;
 esac
 

--- a/deb-get
+++ b/deb-get
@@ -2577,6 +2577,7 @@ case "${OS_ID}" in
   Pop) OS_ID_PRETTY="Pop!_OS";;
   Ubuntu) OS_ID_PRETTY="Ubuntu";;
   Zorin) OS_ID_PRETTY="Zorin OS";;
+  #Kali) OS_ID_PRETTY="Kali GNU/Linux Rolling"
   *) fancy_message fatal "${OS_ID} is not supported.";;
 esac
 
@@ -2608,7 +2609,13 @@ case "${UPSTREAM_CODENAME}" in
     impish)   UPSTREAM_RELEASE="21.10";;
     jammy)    UPSTREAM_RELEASE="22.04";;
     kinetic)  UPSTREAM_RELEASE="22.10";;
-    *) fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release.";;
+    *) 
+        if [ "$OS_ID_PRETTY" == "Kali GNU/Linux Rolling" ]; then
+            return 1
+        else
+        
+            fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release."
+        fi
 esac
 
 if [ -n "${1}" ]; then

--- a/deb-get
+++ b/deb-get
@@ -2613,7 +2613,6 @@ case "${UPSTREAM_CODENAME}" in
         if [ "$OS_ID_PRETTY" == "Kali GNU/Linux Rolling" ]; then
             return 1
         else
-        
             fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release."
         fi
 esac

--- a/deb-get
+++ b/deb-get
@@ -2577,7 +2577,7 @@ case "${OS_ID}" in
   Pop) OS_ID_PRETTY="Pop!_OS";;
   Ubuntu) OS_ID_PRETTY="Ubuntu";;
   Zorin) OS_ID_PRETTY="Zorin OS";;
-  Kali) OS_ID_PRETTY="Kali GNU/Linux Rolling";;
+  Kali) OS_ID_PRETTY="Kali GNU/Linux Rolling";;# add Kali support
   *) fancy_message fatal "${OS_ID} is not supported.";;
 esac
 
@@ -2596,6 +2596,12 @@ if [ -e /etc/os-release ]; then
         debian) UPSTREAM_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2);;
         *) UPSTREAM_CODENAME="";;
     esac
+
+    # Set UPSTREAM_CODENAME to focal OS_ID_PRETTY is Kali GNU/Linux Rolling
+    # To emulate a Debian derived release
+    if [ "${OS_ID_PRETTY}" == "Kali GNU/Linux Rolling" ]; then
+        UPSTREAM_CODENAME="focal"
+    fi
 else
     fancy_message fatal "/etc/os-release not found. Quitting"
 fi
@@ -2609,12 +2615,7 @@ case "${UPSTREAM_CODENAME}" in
     impish)   UPSTREAM_RELEASE="21.10";;
     jammy)    UPSTREAM_RELEASE="22.04";;
     kinetic)  UPSTREAM_RELEASE="22.10";;
-    *) 
-        if [ "$OS_ID_PRETTY" == "Kali GNU/Linux Rolling" ]; then
-            return 1
-        else
-            fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release."
-        fi
+    *) fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release.";;
 esac
 
 if [ -n "${1}" ]; then

--- a/deb-get
+++ b/deb-get
@@ -2578,31 +2578,57 @@ case "${OS_ID}" in
   Ubuntu) OS_ID_PRETTY="Ubuntu";;
   Zorin) OS_ID_PRETTY="Zorin OS";;
   Kali) OS_ID_PRETTY="Kali GNU/Linux Rolling";;# add Kali support
-  *) fancy_message fatal "${OS_ID} is not supported.";;
+  *)
+    OS_ID_PRETTY="${OS_ID}"
+    fancy_message warn "${OS_ID} is not supported."
+  ;;
 esac
 
 OS_CODENAME=$(lsb_release --codename --short)
+
 if [ -e /etc/os-release ]; then
-    UPSTREAM_ID="$(grep "^ID=" /etc/os-release | cut -d'=' -f2)"
-
-    # kali-rolling while debian based does no include a debian CODENAME
-    # so must check if UPSTREAM_ID is kali
-    # Fallback to ID_LIKE if ID was not 'ubuntu' or 'debian' or 'kali'
-    if [ "${UPSTREAM_ID}" != "kali" ] && [ "${UPSTREAM_ID}" != "debian" ] && [ "${UPSTREAM_ID}" != "ubuntu" ]; then
-        UPSTREAM_ID_LIKE="$(grep "^ID_LIKE=" /etc/os-release | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1)"
-        UPSTREAM_ID="${UPSTREAM_ID_LIKE}"
-    fi
-
-    case "${UPSTREAM_ID}" in
-        ubuntu) UPSTREAM_CODENAME=$(grep UBUNTU_CODENAME /etc/os-release | cut -d'=' -f2);;
-        debian) UPSTREAM_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2);;
-        # Set UPSTREAM_CODENAME to kali-rolling and strip out extra characters.
-        kali) UPSTREAM_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1);;
-        *) UPSTREAM_CODENAME="";;
-    esac
-
+    OS_RELEASE=/etc/os-release
+elif [ -e /usr/lib/os-release ]; then
+    OS_RELEASE=/usr/lib/os-release
 else
-    fancy_message fatal "/etc/os-release not found. Quitting"
+    fancy_message fatal "os-release not found. Quitting"
+fi
+
+UPSTREAM_ID="$(grep "^ID=" /etc/os-release | cut -d'=' -f2)"
+
+# kali-rolling while debian based does no include a debian CODENAME
+# so must check if UPSTREAM_ID is kali
+# Fallback to ID_LIKE if ID was not 'ubuntu' or 'debian' or 'kali'
+if [ "${UPSTREAM_ID}" != kali ] &&[ "${UPSTREAM_ID}" != ubuntu ] && [ "${UPSTREAM_ID}" != debian ]; then
+    UPSTREAM_ID_LIKE="$(grep "^ID_LIKE=" ${OS_RELEASE} | cut -d'=' -f2 | cut -d \" -f 2)"
+
+    if [[ " ${UPSTREAM_ID_LIKE} " =~ " ubuntu " ]]; then
+        UPSTREAM_ID=ubuntu
+    elif [[ " ${UPSTREAM_ID_LIKE} " =~ " debian " ]]; then
+        UPSTREAM_ID=debian
+    else
+        fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release."
+    fi
+fi
+
+# if UPSTREAM_ID is kali then set UPSTREAM_CODENAME to kali-rolling otherwise set to UBUNTU_CODENAME
+if [ "${UPSTREAM_ID}" = kali ]; then
+    UPSTREAM_CODENAME=$(grep "^VERSION_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1)
+else
+    UPSTREAM_CODENAME=$(grep "^UBUNTU_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)
+fi
+
+if [ -z "${UPSTREAM_CODENAME}" ]; then
+    UPSTREAM_CODENAME=$(grep "^DEBIAN_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)
+fi
+
+if [ -z "${UPSTREAM_CODENAME}" ]; then
+    UPSTREAM_CODENAME=$(grep "^VERSION_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)   
+fi
+
+# Debian 12+
+if [ -z "${UPSTREAM_CODENAME}" ] && [ -e /etc/debian_version ]; then
+    UPSTREAM_CODENAME=$(cut -d / -f 1 /etc/debian_version)
 fi
 
 case "${UPSTREAM_CODENAME}" in

--- a/deb-get
+++ b/deb-get
@@ -2585,8 +2585,10 @@ OS_CODENAME=$(lsb_release --codename --short)
 if [ -e /etc/os-release ]; then
     UPSTREAM_ID="$(grep "^ID=" /etc/os-release | cut -d'=' -f2)"
 
-    # Fallback to ID_LIKE if ID was not 'ubuntu' or 'debian'
-    if [ "${UPSTREAM_ID}" != "debian" ] && [ "${UPSTREAM_ID}" != "ubuntu" ]; then
+    # kali-rolling while debian based does no include a debian CODENAME
+    # so must check if UPSTREAM_ID is kali
+    # Fallback to ID_LIKE if ID was not 'ubuntu' or 'debian' or 'kali'
+    if [ "${UPSTREAM_ID}" != "kali" ] && [ "${UPSTREAM_ID}" != "debian" ] && [ "${UPSTREAM_ID}" != "ubuntu" ]; then
         UPSTREAM_ID_LIKE="$(grep "^ID_LIKE=" /etc/os-release | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1)"
         UPSTREAM_ID="${UPSTREAM_ID_LIKE}"
     fi
@@ -2594,14 +2596,11 @@ if [ -e /etc/os-release ]; then
     case "${UPSTREAM_ID}" in
         ubuntu) UPSTREAM_CODENAME=$(grep UBUNTU_CODENAME /etc/os-release | cut -d'=' -f2);;
         debian) UPSTREAM_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2);;
+        # Set UPSTREAM_CODENAME to kali-rolling and strip out extra characters.
+        kali) UPSTREAM_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1);;
         *) UPSTREAM_CODENAME="";;
     esac
 
-    # Set UPSTREAM_CODENAME to focal OS_ID_PRETTY is Kali GNU/Linux Rolling
-    # To emulate a Debian derived release
-    if [ "${OS_ID_PRETTY}" == "Kali GNU/Linux Rolling" ]; then
-        UPSTREAM_CODENAME="focal"
-    fi
 else
     fancy_message fatal "/etc/os-release not found. Quitting"
 fi
@@ -2615,6 +2614,7 @@ case "${UPSTREAM_CODENAME}" in
     impish)   UPSTREAM_RELEASE="21.10";;
     jammy)    UPSTREAM_RELEASE="22.04";;
     kinetic)  UPSTREAM_RELEASE="22.10";;
+    kali-rolling)  UPSTREAM_RELEASE="2022.3";; # Add kali-rolling
     *) fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release.";;
 esac
 

--- a/deb-get
+++ b/deb-get
@@ -2669,7 +2669,6 @@ case "${OS_ID}" in
   Pop) OS_ID_PRETTY="Pop!_OS";;
   Ubuntu) OS_ID_PRETTY="Ubuntu";;
   Zorin) OS_ID_PRETTY="Zorin OS";;
-
   Kali) OS_ID_PRETTY="Kali GNU/Linux Rolling";;# add Kali support
   *)
     OS_ID_PRETTY="${OS_ID}"

--- a/deb-get
+++ b/deb-get
@@ -2596,10 +2596,8 @@ fi
 
 UPSTREAM_ID="$(grep "^ID=" /etc/os-release | cut -d'=' -f2)"
 
-# kali-rolling while debian based does no include a debian CODENAME
-# so must check if UPSTREAM_ID is kali
-# Fallback to ID_LIKE if ID was not 'ubuntu' or 'debian' or 'kali'
-if [ "${UPSTREAM_ID}" != kali ] &&[ "${UPSTREAM_ID}" != ubuntu ] && [ "${UPSTREAM_ID}" != debian ]; then
+# Fallback to ID_LIKE if ID was not 'ubuntu' or 'debian'
+if [ "${UPSTREAM_ID}" != ubuntu ] && [ "${UPSTREAM_ID}" != debian ]; then
     UPSTREAM_ID_LIKE="$(grep "^ID_LIKE=" ${OS_RELEASE} | cut -d'=' -f2 | cut -d \" -f 2)"
 
     if [[ " ${UPSTREAM_ID_LIKE} " =~ " ubuntu " ]]; then
@@ -2611,19 +2609,15 @@ if [ "${UPSTREAM_ID}" != kali ] &&[ "${UPSTREAM_ID}" != ubuntu ] && [ "${UPSTREA
     fi
 fi
 
-# if UPSTREAM_ID is kali then set UPSTREAM_CODENAME to kali-rolling otherwise set to UBUNTU_CODENAME
-if [ "${UPSTREAM_ID}" = kali ]; then
-    UPSTREAM_CODENAME=$(grep "^VERSION_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1)
-else
-    UPSTREAM_CODENAME=$(grep "^UBUNTU_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)
-fi
+UPSTREAM_CODENAME=$(grep "^UBUNTU_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)
 
 if [ -z "${UPSTREAM_CODENAME}" ]; then
     UPSTREAM_CODENAME=$(grep "^DEBIAN_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)
 fi
 
+# Strip extra spaces found in /etc/od-release for kali for proper function of UPSTREAM_CODENAME case
 if [ -z "${UPSTREAM_CODENAME}" ]; then
-    UPSTREAM_CODENAME=$(grep "^VERSION_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)   
+    UPSTREAM_CODENAME=$(grep "^VERSION_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1)   
 fi
 
 # Debian 12+


### PR DESCRIPTION
Added support for Kali in the OS_ID section on line 2580 just below Zorin.

At line 2603 assigns "focal" to UPSTREAM_CODENAME if the OS_ID_PRETTY is "Kali GNU/Linux Rolling" otherwise UPSTREAM_CODENAME remains empty.

Tested install from:
curl -sL https://raw.githubusercontent.com/ikeman32/deb-get/KaliSupport/deb-get | sudo -E bash -s install deb-get

And installs to a Kali VM without issue.

Successful installs of Obsidian and VS Codium so same VM.