### PR TITLE
Fix UPSTREAM_CODENAME for Debian 12+

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2604,31 +2604,50 @@ case "${OS_ID}" in
   Pop) OS_ID_PRETTY="Pop!_OS";;
   Ubuntu) OS_ID_PRETTY="Ubuntu";;
   Zorin) OS_ID_PRETTY="Zorin OS";;
-  *) fancy_message fatal "${OS_ID} is not supported.";;
+  *)
+    OS_ID_PRETTY="${OS_ID}"
+    fancy_message warn "${OS_ID} is not supported."
+  ;;
 esac
 
 OS_CODENAME=$(lsb_release --codename --short)
+
 if [ -e /etc/os-release ]; then
-    UPSTREAM_ID="$(grep "^ID=" /etc/os-release | cut -d'=' -f2)"
-
-    # Fallback to ID_LIKE if ID was not 'ubuntu' or 'debian'
-    if [ "${UPSTREAM_ID}" != "debian" ] && [ "${UPSTREAM_ID}" != "ubuntu" ]; then
-        UPSTREAM_ID_LIKE="$(grep "^ID_LIKE=" /etc/os-release | cut -d'=' -f2 | sed s/\"//g | cut -d' ' -f1)"
-        UPSTREAM_ID="${UPSTREAM_ID_LIKE}"
-    fi
-
-    case "${UPSTREAM_ID}" in
-        ubuntu) UPSTREAM_CODENAME=$(grep UBUNTU_CODENAME /etc/os-release | cut -d'=' -f2);;
-        debian)
-            UPSTREAM_CODENAME=$(grep DEBIAN_CODENAME /etc/os-release | cut -d'=' -f2)
-            if [ -z "${UPSTREAM_CODENAME}" ]; then
-                UPSTREAM_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2)
-            fi
-        ;;
-        *) UPSTREAM_CODENAME="";;
-    esac
+    OS_RELEASE=/etc/os-release
+elif [ -e /usr/lib/os-release ]; then
+    OS_RELEASE=/usr/lib/os-release
 else
-    fancy_message fatal "/etc/os-release not found. Quitting"
+    fancy_message fatal "os-release not found. Quitting"
+fi
+
+UPSTREAM_ID="$(grep "^ID=" ${OS_RELEASE} | cut -d'=' -f2)"
+
+# Fallback to ID_LIKE if ID was not 'ubuntu' or 'debian'
+if [ "${UPSTREAM_ID}" != ubuntu ] && [ "${UPSTREAM_ID}" != debian ]; then
+    UPSTREAM_ID_LIKE="$(grep "^ID_LIKE=" ${OS_RELEASE} | cut -d'=' -f2 | cut -d \" -f 2)"
+
+    if [[ " ${UPSTREAM_ID_LIKE} " =~ " ubuntu " ]]; then
+        UPSTREAM_ID=ubuntu
+    elif [[ " ${UPSTREAM_ID_LIKE} " =~ " debian " ]]; then
+        UPSTREAM_ID=debian
+    else
+        fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release."
+    fi
+fi
+
+UPSTREAM_CODENAME=$(grep "^UBUNTU_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)
+
+if [ -z "${UPSTREAM_CODENAME}" ]; then
+    UPSTREAM_CODENAME=$(grep "^DEBIAN_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)
+fi
+
+if [ -z "${UPSTREAM_CODENAME}" ]; then
+    UPSTREAM_CODENAME=$(grep "^VERSION_CODENAME=" ${OS_RELEASE} | cut -d'=' -f2)
+fi
+
+# Debian 12+
+if [ -z "${UPSTREAM_CODENAME}" ] && [ -e /etc/debian_version ]; then
+    UPSTREAM_CODENAME=$(cut -d / -f 1 /etc/debian_version)
 fi
 
 case "${UPSTREAM_CODENAME}" in


### PR DESCRIPTION
- Replace fatal with warn message when `OS_ID` is not supported;
- Fallback to `/usr/lib/os-release` when `/etc/os-release` is not available;
- Improve parsing of `ID_LIKE`;
- Fallback to `/etc/debian_version` when neither `UBUNTU_CODENAME`, `DEBIAN_CODENAME` nor `VERSION_CODENAME` are found in `os-release` (fixes #487).