### PR TITLE
allow AppimageLauncher to be installed in Debian

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2481,7 +2481,12 @@ function deb_papirus-icon-theme() {
 }
 
 function deb_appimagelauncher() {
-    PPA="ppa:appimagelauncher-team/stable"
+    ARCHS_SUPPORTED="amd64 i386 armhf arm64"
+    get_github_releases "https://api.github.com/repos/TheAssassin/AppImageLauncher/releases"
+    if [ "${ACTION}" != "prettylist" ]; then
+        URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v xenial | head -n1 | cut -d '"' -f4)"
+        VERSION_PUBLISHED="$(echo "${URL}" | cut -d '_' -f2 | cut -d '-' -f1)"
+    fi
     PRETTY_NAME="AppImage Launcher"
     WEBSITE="https://github.com/TheAssassin/AppImageLauncher"
     SUMMARY="A free and open source MIT licensed app that makes your Linux desktop AppImage ready. Integrate AppImages to your application launcher with one click, and manage, update and remove them from there."


### PR DESCRIPTION
fixes #520 

This provides a way to install AppimageLauncher in Debian, while continuing to use the PPA in Ubuntu.