### PR TITLE
fix: Extend test coverage on basic commands

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,9 +28,17 @@ jobs:
         run: |
           ./deb-get update >/dev/null
           ./deb-get list >/dev/null
+          ./deb-get prettylist >/dev/null
+          ./deb-get csvlist >/dev/null
+          ./deb-get show deb-get >/dev/null
           ./deb-get help >/dev/null
           ./deb-get cache >/dev/null
           ./deb-get version >/dev/null
+          ./deb-get clean >/dev/null
+
+      # upgrade is skipped because of full system upgrade and otherwise testing package installs
+      # covers most of that. Seperate job/workflow for occassional upgrade validation
+      # say when tagging for release might be good.
 
       # Install a couple of packages to see if they still install
       - name: Test package installations


### PR DESCRIPTION
to catch breakage of more commands

fixes #545 