### PR TITLE
Fix for #551: deb-get prettylist is broken in main

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -357,7 +357,8 @@ function validate_deb() {
     elif  [ -n "${PPA}" ]; then
         METHOD="ppa"
     else
-        if (([ "${METHOD}" = github ] && [ -e "${CACHE_DIR}/${APP}.json" ]) || ([ "${METHOD}" != github ] && [ "${ACTION}" != "prettylist" ])) && ([ -z "${URL}" ] || [ -z "${VERSION_PUBLISHED}" ]); then
+        # METHOD = github or direct
+        if ([ "${ACTION}" != "prettylist" ])  && ([ -z "${URL}" ] || [ -z "${VERSION_PUBLISHED}" ]); then
             fancy_message error "Missing required information of ${METHOD} package ${APP}:"
             echo "URL=${URL}"
             echo "VERSION_PUBLISHED=${VERSION_PUBLISHED}"


### PR DESCRIPTION
Changed validation logic so pretty list won't barf when a cached releases json file exists.