### PR TITLE
Make deb-get executable in test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
       # All these commands should return a 0 status
       - name: Test zero status
         run: |
+          chmod a+x ./deb-get
           ./deb-get update >/dev/null
           ./deb-get list >/dev/null
           ./deb-get help >/dev/null


### PR DESCRIPTION
This resolves the issue where `deb-get` in some PRs is not set as executable, producing a "Permission denied" error in the test workflow. Possibly related to #456.