### PR TITLE
feat(glow): Add the Glow binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ cog.out(pretty_list)
 | [<img src=".github/github.png" align="top" width="20" />](https://desktop.github.com/) | `github-desktop` | <i>Simple collaboration from your desktop.</i> |
 | [<img src=".github/direct.png" align="top" width="20" />](https://www.gitkraken.com/invite/ieih1QR3) | `gitkraken` | <i>Intuitive Git GUI & powerful Git CLI.</i> |
 | [<img src=".github/direct.png" align="top" width="20" />](https://gitter.im/) | `gitter` | <i>A chat and networking platform to manage and connect communities through messaging, content and discovery.</i> |
+| [<img src=".github/debian.png" align="top" width="20" />](https://github.com/charmbracelet/glow) | `glow` | <i>Glow is a terminal based markdown reader designed from the ground up to bring out the beauty—and power—of the CLI.</i> |
 | [<img src=".github/github.png" align="top" width="20" />](https://github.com/ankurk91/google-chat-electron) | `google-chat-electron` | <i>An unofficial desktop app for Google Chat.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://www.google.com/chrome/) | `google-chrome-stable` | <i>Fast, Secure Browser from Google.</i> |
 | [<img src=".github/debian.png" align="top" width="20" />](https://cloud.google.com/sdk/gcloud) | `google-cloud-cli` | <i>The Google Cloud CLI is a set of tools to create and manage Google Cloud resources.</i> |

--- a/deb-get
+++ b/deb-get
@@ -2807,6 +2807,15 @@ function deb_tabby-terminal() {
     SUMMARY="A terminal for the modern age"
 }
 
+function deb_glow() {
+    ASC_KEY_URL="https://repo.charm.sh/apt/gpg.key"
+    APT_LIST_NAME="charm"
+    APT_REPO_URL="https://repo.charm.sh/apt/ * *"
+    PRETTY_NAME="Glow"
+    WEBSITE="https://github.com/charmbracelet/glow"
+    SUMMARY="Glow is a terminal based markdown reader designed from the ground up to bring out the beauty—and power—of the CLI."
+}
+
 # Create an array to track those deb_ functions being loaded by this script
 readonly DEB_GET_APPS=($(declare -F | grep deb_ | sed 's|declare -f deb_||g' | sort))
 


### PR DESCRIPTION
STATE:
Glow is a terminal based markdown reader designed from the ground up to
bring out the beauty—and power—of the CLI.

Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>
