### PR TITLE
Added Virtualbox 7.0

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -644,6 +644,17 @@ function deb_virtualbox-6.1() {
     SUMMARY="VirtualBox 6.1 is a general-purpose full virtualizer for x86 hardware, targeted at server, desktop and embedded use."
 }
 
+function deb_virtualbox-7.0() {
+    ARCHS_SUPPORTED="amd64"
+    ASC_KEY_URL="https://www.virtualbox.org/download/oracle_vbox_2016.asc"
+    APT_LIST_NAME="virtualbox"
+    APT_REPO_URL="https://download.virtualbox.org/virtualbox/debian ${UPSTREAM_CODENAME} contrib"
+    APT_REPO_OPTIONS="arch=amd64"
+    PRETTY_NAME="VirtualBox 7.0"
+    WEBSITE="https://www.virtualbox.org/"
+    SUMMARY="VirtualBox 7.0 is a general-purpose full virtualizer for x86 hardware, targeted at server, desktop and embedded use."
+}
+
 function deb_firefox-esr() {
     PPA="ppa:mozillateam/ppa"
     PRETTY_NAME="Firefox ESR"


### PR DESCRIPTION
see #576
you can't just update the version because they rename the package itself <sigh> ....
6.x can be left for a while to allow users to migrate - installing 7.0 will remove 6.1
