### PR TITLE
fix: don't list all the supported packages if a package is not supported

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -303,7 +303,6 @@ function validate_deb() {
 
     if [[ ! " ${APPS[*]} " =~ " ${APP} " ]]; then
         fancy_message error "${APP} is not a supported application."
-        list_debs >&2
         exit 1
     fi
 


### PR DESCRIPTION
Previous behaviour:

![Screenshot from 2022-10-16 12-31-12](https://user-images.githubusercontent.com/95736269/196022826-ca15670e-c468-4394-855f-1f9d908e2d70.png)

After fix:

![Screenshot from 2022-10-16 12-31-47](https://user-images.githubusercontent.com/95736269/196022835-20ed4443-4131-43fd-abf4-ae773ccf9fdb.png)

It is very annoying when it shows the complete big list just because of a typo or showing the details of a package not supported.