### PR TITLE
fake gitkraken for unpublised version

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1699,7 +1699,7 @@ function deb_vivaldi-stable() {
 
 function deb_gitkraken() {
     if [ "${ACTION}" != "prettylist" ]; then
-        VERSION_PUBLISHED="$(curl -s "https://help.gitkraken.com/gitkraken-client/current/" | grep 'id="version-' | head -n1 | sed -e 's/<[^>]*>//g' | cut -d' ' -f2)"
+        VERSION_PUBLISHED="$(curl -s "https://help.gitkraken.com/gitkraken-client/current/" | grep 'id="version-' | head -n1 | sed -e 's/<[^>]*>//g' | cut -d' ' -f2|sed 's/8.10.0/8.9.1/')"
     fi
     URL="https://release.gitkraken.com/linux/gitkraken-amd64.deb"
     PRETTY_NAME="GitKraken"


### PR DESCRIPTION
Avoid repeated re-installs of 8.9.1 because they have pulled 8.10.0 but left it in the release list

Draft because we don't really want to merge this but it seems to do the job