### PR TITLE
align virtualbox APT_LIST_NAMEs :bug:

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -636,7 +636,7 @@ function deb_quickemu() {
 function deb_virtualbox-6.1() {
     ARCHS_SUPPORTED="amd64"
     ASC_KEY_URL="https://www.virtualbox.org/download/oracle_vbox_2016.asc"
-    APT_LIST_NAME="virtualbox-6.1"
+    APT_LIST_NAME="virtualbox"
     APT_REPO_URL="https://download.virtualbox.org/virtualbox/debian ${UPSTREAM_CODENAME} contrib"
     APT_REPO_OPTIONS="arch=amd64"
     PRETTY_NAME="VirtualBox 6.1"


### PR DESCRIPTION
unless they are aligned there will be a bogus clash of keys

if 6.x has been installed with the old listname it is simplest to remove the old list