### PR TITLE
Fix openrgb

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2409,7 +2409,7 @@ function disabled_deb_openrgb() {
     # due to uninstallable dependencies
     ARCHS_SUPPORTED="amd64 i386 armhf"
     if [ "${ACTION}" != "prettylist" ]; then
-            case "${UPSTREAM_CODENAME}" in
+        case "${UPSTREAM_CODENAME}" in
             focal)
                 URL="https://openrgb.org/up_/up_/static/$(curl -s https://openrgb.org/releases.html | grep -o -e "/releases/release_.\../openrgb_.*_${HOST_ARCH}_.*buster_.*\.deb\""|cut -d"\"" -f 1)"
             ;;
@@ -2417,7 +2417,7 @@ function disabled_deb_openrgb() {
                 URL="https://openrgb.org/up_/up_/static/$(curl -s https://openrgb.org/releases.html | grep -o -e "/releases/release_.\../openrgb_.*_${HOST_ARCH}_.*bullseye_.*\.deb\""|cut -d"\"" -f 5 | cut -d "/" -f 5-)"
             ;;
         esac
-        VERSION_PUBLISHED="$(echo "${URL}" | cut -d "_" -f 3)"
+        VERSION_PUBLISHED="$(echo "${URL}" | grep -o -E '[[:digit:]]+\.[[:digit:]]+'|sort -u)"
     fi
     PRETTY_NAME="OpenRGB"
     WEBSITE="https://openrgb.org/"

--- a/deb-get
+++ b/deb-get
@@ -2404,15 +2404,17 @@ function deb_fsearch() {
     SUMMARY="Fast file search utility."
 }
 
-function deb_openrgb() {
+function disabled_deb_openrgb() {
+    # even when you get to the right files they fail to install
+    # due to uninstallable dependencies
     ARCHS_SUPPORTED="amd64 i386 armhf"
     if [ "${ACTION}" != "prettylist" ]; then
-        case "${UPSTREAM_CODENAME}" in
+            case "${UPSTREAM_CODENAME}" in
             focal)
-                URL="https://openrgb.org/$(curl -s https://openrgb.org/releases.html | grep -o "\"releases/.*/openrgb_.*_${HOST_ARCH}.*buster_.*\.deb\"" | sort --version-sort | tail -n1 | cut -d "\"" -f 2)"
+                URL="https://openrgb.org/up_/up_/static/$(curl -s https://openrgb.org/releases.html | grep -o -e "/releases/release_.\../openrgb_.*_${HOST_ARCH}_.*buster_.*\.deb\""|cut -d"\"" -f 1)"
             ;;
             *)
-                URL="https://openrgb.org/$(curl -s https://openrgb.org/releases.html | grep -o "\"releases/.*/openrgb_.*_${HOST_ARCH}.*bullseye_.*\.deb\"" | sort --version-sort | tail -n1 | cut -d "\"" -f 2)"
+                URL="https://openrgb.org/up_/up_/static/$(curl -s https://openrgb.org/releases.html | grep -o -e "/releases/release_.\../openrgb_.*_${HOST_ARCH}_.*bullseye_.*\.deb\""|cut -d"\"" -f 5 | cut -d "/" -f 5-)"
             ;;
         esac
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d "_" -f 3)"
@@ -2421,6 +2423,7 @@ function deb_openrgb() {
     WEBSITE="https://openrgb.org/"
     SUMMARY="Open source RGB lighting control that doesn't depend on manufacturer software."
 }
+
 
 function deb_mergerfs() {
     ARCHS_SUPPORTED="amd64 arm64 armhf"


### PR DESCRIPTION
fixes #604

disabled the function, which is fixed to get the right URL  and version (currently), but which then fails to install due to unmet dependencies