### PR TITLE
Update Lens url

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -2737,7 +2737,7 @@ function deb_texworks() {
 function deb_lens() {
     ARCHS_SUPPORTED="amd64"
     if [ "${ACTION}" != "prettylist" ]; then
-        URL=$(curl -s https://docs.k8slens.dev/main/getting-started/install-lens/ | grep amd64.deb | cut -d'"' -f2)
+        URL="$(curl -s https://api.k8slens.dev/binaries/latest | rev | cut -d' ' -f1 | rev).amd64.deb"
         VERSION_PUBLISHED="$(echo "${URL}" | cut -d'"' -f2 | cut -d"-" -f2)"
     fi
     PRETTY_NAME="Lens"


### PR DESCRIPTION
This overrides #610 

Update the url parsed to get the .deb file for Lens Kubernetes manager