### PR TITLE
Add sunshine

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -167,6 +167,7 @@ strawberry
 stremio
 sublime-merge
 sublime-text
+sunshine
 surfshark
 syft
 syncthing

--- a/01-main/packages/sunshine
+++ b/01-main/packages/sunshine
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "https://api.github.com/repos/LizardByte/Sunshine/releases/latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | sed 's|^v||')"
+fi
+PRETTY_NAME="Sunshine"
+WEBSITE="https://docs.lizardbyte.dev/projects/sunshine/"
+SUMMARY="Sunshine is a Gamestream host for Moonlight."


### PR DESCRIPTION
Adds support for `sunshine`, an nVidia gamestream host.