### PR TITLE
Fix flameshot to use jammy release until kinetic is built

### DIFF
--- a/01-main/packages/flameshot
+++ b/01-main/packages/flameshot
@@ -1,8 +1,12 @@
-DEFVER=3
+DEFVER=1
 CODENAMES_SUPPORTED="buster bullseye focal jammy kinetic"
 get_github_releases "https://api.github.com/repos/flameshot-org/flameshot/releases/latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(grep  -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}.*\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | tail -n1 | cut -d'"' -f4)"
+    case ${UPSTREAM_RELEASE} in
+        22.10) ONLY_ONE="tail -1" ;;
+        *) ONLY_ONE="head -1"
+    esac
+    URL="$(grep  -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}.*\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | $ONLY_ONE | cut -d'"' -f4)"
     local VERSION_TMP="${URL##*/flameshot-}"
     VERSION_PUBLISHED="${VERSION_TMP%%[-.]${UPSTREAM_ID}*}"
 fi

--- a/01-main/packages/flameshot
+++ b/01-main/packages/flameshot
@@ -1,9 +1,10 @@
-DEFVER=1
+DEFVER=3
+CODENAMES_SUPPORTED="buster bullseye focal jammy kinetic"
 get_github_releases "https://api.github.com/repos/flameshot-org/flameshot/releases/latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(grep "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE}\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)"
+    URL="$(grep  -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}\.[[:digit:]]+\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | tail -n1 | cut -d'"' -f4)"
     local VERSION_TMP="${URL##*/flameshot-}"
-    VERSION_PUBLISHED="${VERSION_TMP%%[-.]ubuntu*}"
+    VERSION_PUBLISHED="${VERSION_TMP%%[-.]${UPSTREAM_ID}*}"
 fi
 PRETTY_NAME="Flameshot"
 WEBSITE="https://flameshot.org/"

--- a/01-main/packages/flameshot
+++ b/01-main/packages/flameshot
@@ -2,7 +2,7 @@ DEFVER=3
 CODENAMES_SUPPORTED="buster bullseye focal jammy kinetic"
 get_github_releases "https://api.github.com/repos/flameshot-org/flameshot/releases/latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(grep  -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}\.[[:digit:]]+\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | tail -n1 | cut -d'"' -f4)"
+    URL="$(grep  -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}.*\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | tail -n1 | cut -d'"' -f4)"
     local VERSION_TMP="${URL##*/flameshot-}"
     VERSION_PUBLISHED="${VERSION_TMP%%[-.]${UPSTREAM_ID}*}"
 fi


### PR DESCRIPTION
Seems to work fine

![image](https://user-images.githubusercontent.com/8797027/198897431-b41c6be7-e34f-4798-b5d7-dcfba754abc3.png)

And also should now work on debian rather than breaking because the old pattern hard-coded 'ubuntu'

