### PR TITLE
pick correct beersmith version for release

### DIFF
--- a/01-main/packages/beersmith3
+++ b/01-main/packages/beersmith3
@@ -1,6 +1,21 @@
 DEFVER=1
+CODENAMES_SUPPORTED="bionic focal jammy kinetic"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(curl -s "https://beersmith.com/download-beersmith/" | grep "amd64\.deb\"" | head -n1 | cut -d'"' -f2)"
+    case ${UPSTREAM_CODENAME} in
+        bionic)
+            URL="$(curl -s "https://beersmith.com/download-beersmith/" | grep "18\.04_amd64\.deb\"" | head -n1 | cut -d'"' -f2)"
+        ;;
+        focal)
+            URL="$(curl -s "https://beersmith.com/download-beersmith/" | grep "3\.2\.7_amd64\.deb\"" | head -n1 | cut -d'"' -f2)"
+        ;;
+        jammy|kinetic)
+            URL="$(curl -s "https://beersmith.com/download-beersmith/" | grep "amd64\.deb\"" | head -n1 | cut -d'"' -f2)"
+        ;;
+        *)
+            URL="$(curl -s "https://beersmith.com/download-beersmith/" | grep "amd64\.deb\"" | head -n1 | cut -d'"' -f2)"
+        ;;
+    esac
+
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'-' -f3 | cut -d'_' -f1)"
 fi
 PRETTY_NAME="BeerSmith"


### PR DESCRIPTION
They don't make it easy. This semi-hard-coding seems necessary for older releases.
Installs and works without issue on kinetic and now should pick the recommended versions for focal and bionic.
[![01-main Tests](https://github.com/philclifford/deb-get/actions/workflows/tests-01-main.yml/badge.svg?branch=correct-beersmith)](https://github.com/philclifford/deb-get/actions/workflows/tests-01-main.yml)