### PR TITLE
Align Makefile destination to packaging

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
 include pandoc-man.mk
 
 ifeq ($(PREFIX),)
-    PREFIX := /usr/local
+    PREFIX := /usr
 endif
 
 datarootdir := $(PREFIX)/share


### PR DESCRIPTION
So that anyone who uses that doesn't end up on a limb. 
Better for the end-users' wellbeing.  
