### PR TITLE
Add Clockify

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -23,6 +23,7 @@ brisqi
 caprine
 cawbird
 chronograf
+clockify
 code
 codium
 com.github.tkashkin.gamehub

--- a/01-main/packages/clockify
+++ b/01-main/packages/clockify
@@ -1,0 +1,6 @@
+DEFVER=1
+VERSION_PUBLISHED="2.0.3"
+URL="https://clockify.me/downloads/Clockify_Setup.deb"
+PRETTY_NAME="Clockify"
+WEBSITE="https://clockify.me/"
+SUMMARY="Clockify is a time tracker and timesheet app that lets you track work hours across projects"


### PR DESCRIPTION
Closes #651.

Note: Clockify version is not exposed anywhere on the website, nor the package URL. So `VERSION_PUBLISHED` had to be hardcoded in the package definition file. 🤷🏻‍♂️ 