### PR TITLE
Fix Mattermost Desktop URL

### DIFF
--- a/01-main/packages/mattermost-desktop
+++ b/01-main/packages/mattermost-desktop
@@ -2,7 +2,7 @@ DEFVER=1
 get_github_releases "https://api.github.com/repos/mattermost/desktop/releases"
 if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED="$(grep "browser_download_url" "${CACHE_DIR}/${APP}.json" | grep -v -e rc | head -n1 | cut -d'"' -f4 | cut -d'/' -f8 | tr -d v)"
-    URL="$(curl https://github.com/mattermost/desktop/releases/ | grep "//releases.*${VERSION_PUBLISHED}.*${HOST_ARCH}\.deb\"" | head -n 1 | cut -d\" -f 2)"
+    URL=$(wget -q https://github.com/mattermost/desktop/releases -O- | grep -v -e 'rc.' | grep -o -E "https.*${VERSION_PUBLISHED}.*${HOST_ARCH}\.deb\"" | tr -d '\"')
 fi
 PRETTY_NAME="Mattermost Desktop"
 WEBSITE="https://mattermost.com/"


### PR DESCRIPTION
They seem to have updated their release info so a viable URL was lost. This fixes it until the next change
Closes #664 