### PR TITLE
deprecate balena-etcher-electron

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -8,7 +8,7 @@ atom
 audio-recorder
 azure-cli
 azuredatastudio
-balena-etcher-electron
+#balena-etcher-electron
 bat
 battery-monitor
 beersmith3


### PR DESCRIPTION
We have a choice to leave this enabled, have users install or upgrade to a version that doesn't run at all and tell them to wait (optionally also to install the AppImage and run it with "--no-sandbox" ) until a working deb upgrade materializes or to deprecate it until it is fixed upstream. My preference is the latter, hence this PR

Raised upstream, where they just showed a list of all the duplicates.  Some of the issues and a respondent to mine mention running the AppImage with "--no-sandbox", but that doesn't work for the deb, which installs "fine" but fails silently from a normal user's perspective. It may be nvidia gpu related, there may be other workarounds ... I use `ddrescue` btw :shrug: 

https://github.com/balena-io/etcher/issues/  

and look for 3873 , which also links to the catalogue of  "duplicates"  :cricket: 