### PR TITLE
filter release candidates from anitmicrox

### DIFF
--- a/01-main/packages/antimicrox
+++ b/01-main/packages/antimicrox
@@ -1,7 +1,7 @@
 DEFVER=1
 get_github_releases "https://api.github.com/repos/AntiMicroX/antimicrox/releases"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_CPU}\.deb\"" "${CACHE_DIR}/${APP}.json" | head -n1 | cut -d'"' -f4)
+    URL=$(grep "browser_download_url.*${HOST_CPU}\.deb\"" "${CACHE_DIR}/${APP}.json" | grep -v -e '\-rc\/anti' | head -n1 | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
 fi
 PRETTY_NAME="AntiMicroX"


### PR DESCRIPTION
The pre-release should be filtered out.
Also, they've published 3.3.2-rc called 3.3.1 as well as 3.3.1 and a HOTFIX also called 3.3.1