### PR TITLE
Missing dependencies mean adjusting debian support

### DIFF
--- a/01-main/packages/battery-monitor
+++ b/01-main/packages/battery-monitor
@@ -1,4 +1,5 @@
 DEFVER=1
+CODENAMES_SUPPORTED="focal jammy kinetic"
 get_github_releases "hsbasu/battery-monitor" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)"

--- a/01-main/packages/stremio
+++ b/01-main/packages/stremio
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="buster bullseye focal"
+CODENAMES_SUPPORTED="buster focal"
 get_website "https://www.stremio.com/downloads"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep -o "dl-linux-four-deb.*amd64\.deb\"" "${CACHE_FILE}" | cut -d "\"" -f 3)"


### PR DESCRIPTION
Checked and these have not been fixed since the mega-test