### PR TITLE
Revert apt/ppa list names to their canonical form

### DIFF
--- a/01-main/packages/1password
+++ b/01-main/packages/1password
@@ -1,6 +1,5 @@
 DEFVER=1
 ASC_KEY_URL="https://downloads.1password.com/linux/keys/1password.asc"
-APT_LIST_NAME="1password"
 APT_REPO_URL="https://downloads.1password.com/linux/debian/amd64 stable main"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="1Password"

--- a/01-main/packages/anydesk
+++ b/01-main/packages/anydesk
@@ -1,5 +1,6 @@
 DEFVER=1
 ASC_KEY_URL="https://keys.anydesk.com/repos/DEB-GPG-KEY"
+APT_LIST_NAME="anydesk-stable"
 APT_REPO_URL="http://deb.anydesk.com/ all main"
 PRETTY_NAME="AnyDesk"
 WEBSITE="https://anydesk.com/"

--- a/01-main/packages/azuredatastudio
+++ b/01-main/packages/azuredatastudio
@@ -8,10 +8,3 @@ fi
 PRETTY_NAME="Azure Data Studio"
 WEBSITE="https://docs.microsoft.com/en-us/sql/azure-data-studio/"
 SUMMARY="Data management tool for working with SQL Server, Azure SQL DB and SQL DW."
-
-function postinst() {
-    if ! grep -m 1 -q "^code " /etc/deb-get/installed; then
-        ${ELEVATE} rm -f /etc/apt/sources.list.d/vscode.list
-    fi
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/microsoft.gpg
-}

--- a/01-main/packages/brave-browser
+++ b/01-main/packages/brave-browser
@@ -1,12 +1,8 @@
 DEFVER=1
 ASC_KEY_URL="https://brave-browser-apt-release.s3.brave.com/brave-core.asc"
-APT_LIST_NAME="brave-browser"
+APT_LIST_NAME="brave-browser-release"
 APT_REPO_URL="https://brave-browser-apt-release.s3.brave.com/ stable main"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Brave"
 WEBSITE="https://brave.com/"
 SUMMARY="Browse privately. Search privately. And ditch Big Tech."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/brave-browser-release.gpg
-}

--- a/01-main/packages/cawbird
+++ b/01-main/packages/cawbird
@@ -6,6 +6,7 @@ if [ "${OBS_UPSTREAM_ID}" == "Ubuntu" ]; then
 fi
 
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:IBBoard:cawbird/${OBS_UPSTREAM_ID}_${UPSTREAM_RELEASE}/Release.key"
+APT_LIST_NAME="home:IBBoard:cawbird"
 APT_REPO_URL="https://download.opensuse.org/repositories/home:/IBBoard:/cawbird/${OBS_UPSTREAM_ID}_${UPSTREAM_RELEASE}/ /"
 PRETTY_NAME="Cawbird"
 WEBSITE="https://ibboard.co.uk/cawbird/"

--- a/01-main/packages/docker-ce
+++ b/01-main/packages/docker-ce
@@ -1,6 +1,7 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armhf"
 ASC_KEY_URL="https://download.docker.com/linux/ubuntu/gpg"
+APT_LIST_NAME="docker"
 APT_REPO_URL="https://download.docker.com/linux/${UPSTREAM_ID} ${UPSTREAM_CODENAME} stable"
 APT_REPO_OPTIONS="arch=${HOST_ARCH}"
 PRETTY_NAME="Docker Engine"

--- a/01-main/packages/dropbox
+++ b/01-main/packages/dropbox
@@ -19,10 +19,3 @@ APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Dropbox"
 WEBSITE="https://www.dropbox.com/"
 SUMMARY="Securely share, store and do more with your content."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/dropbox.list
-    if which apt-key > /dev/null; then
-        ${ELEVATE} apt-key del "1C61 A265 6FB5 7B7E 4DE0  F4C1 FC91 8B33 5044 912E" >& /dev/null
-    fi
-}

--- a/01-main/packages/element-desktop
+++ b/01-main/packages/element-desktop
@@ -1,5 +1,6 @@
 DEFVER=1
 GPG_KEY_URL="https://packages.element.io/debian/element-io-archive-keyring.gpg"
+APT_LIST_NAME="element-io"
 APT_REPO_URL="https://packages.element.io/debian/ default main"
 PRETTY_NAME="Element"
 WEBSITE="https://element.io/"

--- a/01-main/packages/google-chrome-stable
+++ b/01-main/packages/google-chrome-stable
@@ -1,13 +1,9 @@
 DEFVER=1
 ASC_KEY_URL="https://dl.google.com/linux/linux_signing_key.pub"
+APT_LIST_NAME="google-chrome"
 APT_REPO_URL="https://dl.google.com/linux/chrome/deb/ stable main"
 APT_REPO_OPTIONS="arch=amd64"
 EULA="By downloading Chrome, you agree to the Google Terms of Service and Chrome and Chrome OS Additional Terms of Service\n - https://policies.google.com/terms\n - https://www.google.co.uk/intl/en/chrome/terms/"
 PRETTY_NAME="Google Chrome"
 WEBSITE="https://www.google.com/chrome/"
 SUMMARY="Fast, Secure Browser from Google."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/google-chrome.list
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/google-chrome.gpg
-}

--- a/01-main/packages/google-earth-pro-stable
+++ b/01-main/packages/google-earth-pro-stable
@@ -1,15 +1,8 @@
 DEFVER=1
 ASC_KEY_URL="https://dl-ssl.google.com/linux/linux_signing_key.pub"
+APT_LIST_NAME="google-earth-pro"
 APT_REPO_URL="https://dl.google.com/linux/earth/deb/ stable main"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Google Earth Pro"
 WEBSITE="https://www.google.com/earth/versions/"
 SUMMARY="Explore worldwide satellite imagery and 3D buildings and terrain for hundreds of cities."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/google-earth-pro.list
-    if which apt-key > /dev/null; then
-        ${ELEVATE} apt-key del "4CCA 1EAF 950C EE4A B839  76DC A040 830F 7FAC 5991" >& /dev/null
-        ${ELEVATE} apt-key del "EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796" >& /dev/null
-    fi
-}

--- a/01-main/packages/headset
+++ b/01-main/packages/headset
@@ -1,6 +1,5 @@
 DEFVER=1
 GPG_KEY_URL="https://headsetapp.co/headset-electron/headset.gpg"
-APT_LIST_NAME="headset"
 APT_REPO_URL="https://headsetapp.co/headset-electron/debian stable non-free"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Headset"

--- a/01-main/packages/insync
+++ b/01-main/packages/insync
@@ -6,7 +6,3 @@ APT_REPO_URL="http://apt.insync.io/${UPSTREAM_ID} ${UPSTREAM_CODENAME} non-free 
 PRETTY_NAME="Insync"
 WEBSITE="https://www.insynchq.com/"
 SUMMARY="Manage your Google Drive, OneDrive, and Dropbox files straight from your Desktop."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/insynchq.gpg
-}

--- a/01-main/packages/keybase
+++ b/01-main/packages/keybase
@@ -4,10 +4,3 @@ APT_REPO_URL="https://prerelease.keybase.io/deb stable main"
 PRETTY_NAME="Keybase"
 WEBSITE="https://keybase.io/"
 SUMMARY="End-to-end encryption for things that matter. Secure messaging and file-sharing."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/keybase.list
-    if which apt-key > /dev/null; then
-        ${ELEVATE} apt-key del "222B 85B0 F90B E2D2 4CFE  B93F 4748 4E50 656D 16C7" >& /dev/null
-    fi
-}

--- a/01-main/packages/kopia-ui
+++ b/01-main/packages/kopia-ui
@@ -1,5 +1,6 @@
 DEFVER=1
 ASC_KEY_URL="https://kopia.io/signing-key"
+APT_LIST_NAME="kopia"
 APT_REPO_URL="https://packages.kopia.io/apt/ stable main"
 PRETTY_NAME="KopiaUI"
 WEBSITE="https://kopia.io/"

--- a/01-main/packages/microsoft-edge-stable
+++ b/01-main/packages/microsoft-edge-stable
@@ -1,12 +1,8 @@
 DEFVER=1
 ASC_KEY_URL="https://packages.microsoft.com/keys/microsoft.asc"
+APT_LIST_NAME="microsoft-edge"
 APT_REPO_URL="https://packages.microsoft.com/repos/edge stable main"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Microsoft Edge"
 WEBSITE="https://www.microsoft.com/edge"
 SUMMARY="Fast and secure browser that helps you protect your data and save time and money."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/microsoft-edge.list
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/microsoft-edge.gpg
-}

--- a/01-main/packages/opera-stable
+++ b/01-main/packages/opera-stable
@@ -1,12 +1,6 @@
 DEFVER=1
 ASC_KEY_URL="https://deb.opera.com/archive.key"
-APT_LIST_NAME="opera-stable"
 APT_REPO_URL="https://deb.opera.com/opera-stable/ stable non-free"
 PRETTY_NAME="Opera"
 WEBSITE="https://www.opera.com/"
 SUMMARY="Faster, safer and smarter than default browsers."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/opera.archive.key.2019.gpg
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/opera.archive.key.2021.gpg
-}

--- a/01-main/packages/plexmediaserver
+++ b/01-main/packages/plexmediaserver
@@ -1,12 +1,7 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armhf"
 ASC_KEY_URL="https://downloads.plex.tv/plex-keys/PlexSign.key"
-APT_LIST_NAME="plexmediaserver"
 APT_REPO_URL="https://downloads.plex.tv/repo/deb public main"
 PRETTY_NAME="Plex"
 WEBSITE="https://www.plex.tv/"
 SUMMARY="Stream Movies and TV Shows."
-
-function postinst() {
-    ${ELEVATE} rm -f /usr/share/keyrings/plexmediaserver.gpg
-}

--- a/01-main/packages/protonvpn
+++ b/01-main/packages/protonvpn
@@ -1,5 +1,6 @@
 DEFVER=1
 ASC_KEY_URL="https://protonvpn.com/download/public_key.asc"
+APT_LIST_NAME="protonvpn-stable"
 APT_REPO_URL="https://repo.protonvpn.com/debian stable main"
 PRETTY_NAME="Proton VPN"
 WEBSITE="https://protonvpn.com/"

--- a/01-main/packages/signal-desktop
+++ b/01-main/packages/signal-desktop
@@ -1,5 +1,6 @@
 DEFVER=1
 ASC_KEY_URL="https://updates.signal.org/desktop/apt/keys.asc"
+APT_LIST_NAME="signal-xenial"
 APT_REPO_URL="https://updates.signal.org/desktop/apt xenial main"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Signal"

--- a/01-main/packages/skypeforlinux
+++ b/01-main/packages/skypeforlinux
@@ -1,14 +1,8 @@
 DEFVER=1
 ASC_KEY_URL="https://repo.skype.com/data/SKYPE-GPG-KEY"
+APT_LIST_NAME="skype-stable"
 APT_REPO_URL="https://repo.skype.com/deb stable main"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Skype"
 WEBSITE="https://www.skype.com/"
 SUMMARY="Stay connected with free video calls worldwide."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/skype-stable.list
-    if which apt-key > /dev/null; then
-        ${ELEVATE} apt-key del "D404 0146 BE39 7250 9FD5  7FC7 1F30 45A5 DF75 87C3" >& /dev/null
-    fi
-}

--- a/01-main/packages/slack-desktop
+++ b/01-main/packages/slack-desktop
@@ -1,5 +1,6 @@
 DEFVER=1
 ASC_KEY_URL="https://packagecloud.io/slacktechnologies/slack/gpgkey"
+APT_LIST_NAME="slack"
 APT_REPO_URL="https://packagecloud.io/slacktechnologies/slack/debian/ jessie main"
 PRETTY_NAME="Slack"
 WEBSITE="https://slack.com/"

--- a/01-main/packages/softmaker-office-2021
+++ b/01-main/packages/softmaker-office-2021
@@ -1,5 +1,6 @@
 DEFVER=1
 ASC_KEY_URL="https://shop.softmaker.com/repo/linux-repo-public.key"
+APT_LIST_NAME="softmaker"
 APT_REPO_URL="https://shop.softmaker.com/repo/apt stable non-free"
 PRETTY_NAME="SoftMaker Office 2021"
 WEBSITE="https://www.softmaker.com/en/softmaker-office"

--- a/01-main/packages/spotify-client
+++ b/01-main/packages/spotify-client
@@ -4,7 +4,3 @@ APT_REPO_URL="http://repository.spotify.com stable non-free"
 PRETTY_NAME="Spotify"
 WEBSITE="https://www.spotify.com/"
 SUMMARY="Millions of songs and podcasts."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/spotify-2021-10-27-5E3C45D7B312C643.gpg
-}

--- a/01-main/packages/sublime-text
+++ b/01-main/packages/sublime-text
@@ -1,6 +1,5 @@
 DEFVER=1
 ASC_KEY_URL="https://download.sublimetext.com/sublimehq-pub.gpg"
-APT_LIST_NAME="sublime-text"
 APT_REPO_URL="https://download.sublimetext.com/ apt/stable/"
 PRETTY_NAME="Sublime Text"
 WEBSITE="https://www.sublimetext.com/"

--- a/01-main/packages/teams
+++ b/01-main/packages/teams
@@ -1,12 +1,7 @@
 DEFVER=1
 ASC_KEY_URL="https://packages.microsoft.com/keys/microsoft.asc"
-APT_LIST_NAME="teams"
 APT_REPO_URL="https://packages.microsoft.com/repos/ms-teams stable main"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Microsoft Teams"
 WEBSITE="https://www.microsoft.com/microsoft-teams/group-chat-software"
 SUMMARY="Team chat and collaboration."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/microsoft.gpg
-}

--- a/01-main/packages/teamviewer
+++ b/01-main/packages/teamviewer
@@ -1,12 +1,6 @@
 DEFVER=2
 ASC_KEY_URL="https://download.teamviewer.com/download/linux/signature/TeamViewer2017.asc"
-APT_LIST_NAME="teamviewer"
 APT_REPO_URL="https://linux.teamviewer.com/deb stable main"
 PRETTY_NAME="TeamViewer"
 WEBSITE="https://www.teamviewer.com/"
 SUMMARY="The Remote Desktop Software."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/teamviewer.list.dpkg-dist
-    ${ELEVATE} rm -f /usr/share/keyrings/teamviewer-keyring.gpg
-}

--- a/01-main/packages/ungoogled-chromium
+++ b/01-main/packages/ungoogled-chromium
@@ -1,4 +1,5 @@
 DEFVER=1
+APT_LIST_NAME="home-ungoogled_chromium"
 case "${UPSTREAM_CODENAME}" in
     focal)
         ASC_KEY_URL="https://download.opensuse.org/repositories/home:/ungoogled_chromium/Ubuntu_Focal/Release.key"

--- a/01-main/packages/vivaldi-stable
+++ b/01-main/packages/vivaldi-stable
@@ -1,14 +1,9 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armhf"
 ASC_KEY_URL="https://repo.vivaldi.com/stable/linux_signing_key.pub"
+APT_LIST_NAME="vivaldi"
 APT_REPO_URL="https://repo.vivaldi.com/stable/deb/ stable main"
 APT_REPO_OPTIONS="arch=${HOST_ARCH}"
 PRETTY_NAME="Vivaldi"
 WEBSITE="https://vivaldi.com/"
 SUMMARY="The most feature-packaged, customisable browser."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/vivaldi.list
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/vivaldi-4218647E.gpg
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/vivaldi-C27AA466.gpg
-}

--- a/01-main/packages/wavebox
+++ b/01-main/packages/wavebox
@@ -1,12 +1,8 @@
 DEFVER=1
 ASC_KEY_URL="https://wavebox.pro/dl/client/repo/archive.key"
+APT_LIST_NAME="wavebox-stable"
 APT_REPO_URL="https://download.wavebox.app/stable/linux/deb/ amd64/"
 APT_REPO_OPTIONS="arch=amd64"
 PRETTY_NAME="Wavebox"
 WEBSITE="https://wavebox.io/"
 SUMMARY="Rethink the Web. Productivity Browser."
-
-function postinst() {
-    ${ELEVATE} rm -f /etc/apt/sources.list.d/wavebox-stable.list
-    ${ELEVATE} rm -f /etc/apt/trusted.gpg.d/wavebox.gpg
-}

--- a/01-main/packages/wraith-master
+++ b/01-main/packages/wraith-master
@@ -1,4 +1,4 @@
-DEFVER=2
+DEFVER=1
 get_github_releases "serebit/wraith-master" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)

--- a/EXTREPO.md
+++ b/EXTREPO.md
@@ -32,7 +32,7 @@ The variables defined in the package definition file are the following:
 * `CODENAMES_SUPPORTED`: A space-separated list of supported upstream codenames, supporting the values from `UPSTREAM_CODENAME`.
 * `ASC_KEY_URL`: A URL to the ASCII-armored keyring file.
 * `GPG_KEY_URL`: A URL to the binary keyring file.
-* `APT_LIST_NAME`: The name of the `*.list` file, without the extension. It should only be used when not doing so would cause problems.
+* `APT_LIST_NAME`: The name of the `*.list` file, without the extension.
 * `APT_REPO_URL`: The repository URL, the distribution codename and any following components for the line that will be printed to the `*.list` file.
 * `APT_REPO_OPTIONS`: The space-separated extra options, such as `arch=` or `by-hash=` for the line that will be printed to the `*.list` file.
 * `PPA`: The PPA address, following the format used by `apt-add-repository`, including the `ppa:` prefix.
@@ -43,7 +43,7 @@ The variables defined in the package definition file are the following:
 * `WEBSITE`: A URL to the official website for the software.
 * `SUMMARY`: A brief description of what the software is and does.
 
-`ARCHS_SUPPORTED`, `CODENAMES_SUPPORTED`, `APT_LIST_NAME`, `APT_REPO_OPTIONS` and `EULA` are optional and can be ommited when not needed. `ARCHS_SUPPORTED` defaults to `amd64`, and `APT_LIST_NAME` defaults to `deb-get-${APP}`. The URLs must use the HTTPS protocol whenever possible (i.e. except when using HTTPS would not work). To ensure the optimal performance of the commands `prettylist` and `csvlist`, if more complex operations (such as `curl`, `unroll_url` or `grep` over the GitHub releases JSON file) are needed to define the variables (most likely `URL` and `VERSION_PUBLISHED`), they (and the variables that depend on them) must be wrapped by the following condition:
+`ARCHS_SUPPORTED`, `CODENAMES_SUPPORTED`, `APT_LIST_NAME`, `APT_REPO_OPTIONS` and `EULA` are optional and can be ommited when not needed. `ARCHS_SUPPORTED` defaults to `amd64`, and `APT_LIST_NAME` defaults to `${APP}`. The URLs must use the HTTPS protocol whenever possible (i.e. except when using HTTPS would not work). To ensure the optimal performance of the commands `prettylist` and `csvlist`, if more complex operations (such as `curl`, `unroll_url` or `grep` over the GitHub releases JSON file) are needed to define the variables (most likely `URL` and `VERSION_PUBLISHED`), they (and the variables that depend on them) must be wrapped by the following condition:
 
 ```bash
 if [ "${ACTION}" != prettylist ]; then

--- a/deb-get
+++ b/deb-get
@@ -406,7 +406,7 @@ function validate_deb() {
     export DEFVER=""
     export ASC_KEY_URL=""
     export GPG_KEY_URL=""
-    export APT_LIST_NAME="deb-get-${APP}"
+    export APT_LIST_NAME="${APP}"
     export APT_REPO_URL=""
     export APT_REPO_OPTIONS=""
     export PPA=""
@@ -766,10 +766,6 @@ function fix_old_apps() {
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="docker"
         ;;
-        element-desktop)
-            OLD_METHOD="apt"
-            OLD_APT_LIST_NAME="element-io"
-        ;;
         enpass)
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="enpass"
@@ -789,10 +785,6 @@ function fix_old_apps() {
         google-chrome-stable)
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="google-chrome"
-        ;;
-        google-cloud-cli)
-            OLD_METHOD="apt"
-            OLD_APT_LIST_NAME="google-cloud-cli"
         ;;
         google-earth-pro-stable)
             OLD_METHOD="apt"
@@ -818,10 +810,6 @@ function fix_old_apps() {
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="insync"
         ;;
-        jami)
-            OLD_METHOD="apt"
-            OLD_APT_LIST_NAME="jami"
-        ;;
         jellyfin)
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="jellyfin"
@@ -845,10 +833,6 @@ function fix_old_apps() {
         kopia-ui)
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="kopia"
-        ;;
-        librewolf)
-            OLD_METHOD="apt"
-            OLD_APT_LIST_NAME="librewolf"
         ;;
         lutris)
             OLD_METHOD="ppa"
@@ -950,10 +934,6 @@ function fix_old_apps() {
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="syncthing"
         ;;
-        tailscale)
-            OLD_METHOD="apt"
-            OLD_APT_LIST_NAME="tailscale"
-        ;;
         teams)
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="teams"
@@ -994,10 +974,6 @@ function fix_old_apps() {
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="wavebox-stable"
         ;;
-        waydroid)
-            OLD_METHOD="apt"
-            OLD_APT_LIST_NAME="waydroid"
-        ;;
         weechat)
             OLD_METHOD="apt"
             OLD_APT_LIST_NAME="weechat"
@@ -1013,10 +989,6 @@ function fix_old_apps() {
         yq)
             OLD_METHOD="ppa"
             OLD_PPA="ppa:rmescandon/yq"
-        ;;
-        zotero)
-            OLD_METHOD="apt"
-            OLD_APT_LIST_NAME="zotero"
         ;;
     esac
     if [ -n "${OLD_METHOD}" ]; then
@@ -1157,6 +1129,7 @@ function ppa_to_apt() {
     local -r PPA_ARCHIVE="$(echo "${PPA_ADDRESS}" | cut -d / -f 2)"
     export APT_REPO_URL="https://ppa.launchpadcontent.net/${PPA_ADDRESS}/ubuntu/ ${UPSTREAM_CODENAME} main"
     export ASC_KEY_URL="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x$(curl -s "https://api.launchpad.net/devel/~${PPA_PERSON}/+archive/ubuntu/${PPA_ARCHIVE}" | grep -o -E "\"signing_key_fingerprint\": \"[0-9A-F]+\"" | cut -d \" -f 4)"
+    export APT_LIST_NAME="${PPA_PERSON}-ubuntu-${PPA_ARCHIVE}-${UPSTREAM_CODENAME}"
 }
 
 function maint_supported_cache() {


### PR DESCRIPTION
Remove `postinst` cleanups, default `APT_LIST_NAME` to `${APP}`.