### PR TITLE
change mergerfs to show jammy release to kinetic

### DIFF
--- a/01-main/packages/mergerfs
+++ b/01-main/packages/mergerfs
@@ -1,9 +1,17 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armhf"
 CODENAMES_SUPPORTED="buster bullseye focal jammy"
-get_github_releases "trapexit/mergerfs" "latest"
+# kinetic"
+get_github_releases "trapexit/mergerfs" 
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(grep "browser_download_url.*.deb" "${CACHE_FILE}" | grep "${UPSTREAM_CODENAME}_${HOST_ARCH}" | cut -d'"' -f4)"
+    case ${UPSTREAM_CODENAME} in
+	kinetic)
+           URL="$(grep "browser_download_url.*.deb" "${CACHE_FILE}" | grep "jammy_${HOST_ARCH}" | cut -d'"' -f4)"
+	;;
+	*)
+          URL="$(grep "browser_download_url.*.deb" "${CACHE_FILE}" | grep "${UPSTREAM_CODENAME}_${HOST_ARCH}" | cut -d'"' -f4)"
+	;;
+   esac
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d _ -f2 | sed -E "s/([0-9])\\.([a-z])/\1~\2/")"
 fi
 PRETTY_NAME="mergerfs"

--- a/01-main/packages/mergerfs
+++ b/01-main/packages/mergerfs
@@ -2,7 +2,7 @@ DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armhf"
 CODENAMES_SUPPORTED="buster bullseye focal jammy"
 # kinetic"
-get_github_releases "trapexit/mergerfs" 
+get_github_releases "trapexit/mergerfs" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     case ${UPSTREAM_CODENAME} in
 	kinetic)


### PR DESCRIPTION
Because there is no kinetic release, kinetic users get problems for update/show/install.  With this in place they have a better experience.

This uses the available `jammy` release on `kinetic` so we don't break : it works for me, but ymmv - and you may prefer not to do this, or to tweak the `grep` to guess and try and catch and prefer `kinetic` should it appear ...
As it stands it will refuse to update/install as kinetic is not in the supported list.
I've built a kinetic deb to compare and maybe put in a PPA ( upstream only builds and supports releases for LTSs) 
That's probably safer than just using the jammy release - better to use an older version from the ubuntu apt repo than that IMO when it comes to file systems.
