### PR TITLE
also filter insomnia alpha releases

### DIFF
--- a/01-main/packages/insomnia
+++ b/01-main/packages/insomnia
@@ -1,7 +1,7 @@
 DEFVER=1
 get_github_releases "Kong/insomnia"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | grep -v beta | head -n1 | cut -d'"' -f4)"
+    URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | grep -v -e beta -e alpha | head -n1 | cut -d'"' -f4)"
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'-' -f2 | sed s'|\.deb||')"
 fi
 PRETTY_NAME="Insomnia"


### PR DESCRIPTION
closes #698 
after recent transient breakage because an alpha release upset `dpkg` with its poor naming.
We were already filtering betas out so just tweaking that should guard against future mishaps.