### PR TITLE
fixed frostwire

### DIFF
--- a/01-main/packages/frostwire
+++ b/01-main/packages/frostwire
@@ -1,5 +1,6 @@
 DEFVER=1
-get_github_releases "frostwire/frostwire" "latest"
+get_github_releases "frostwire/frostwire"
+#"latest" cannot be used here
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*amd64\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'-' -f3)"


### PR DESCRIPTION
we cannot use latest when they are releasing various things in the one repo
closes #717 