### PR TITLE
Add ToneLib apps

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -198,6 +198,7 @@ terraform
 texworks
 tidal-hifi
 tixati
+tonelib-zoom
 tribler
 trivy
 typora

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -199,6 +199,9 @@ texworks
 tidal-hifi
 tixati
 tonelib-bassdrive
+tonelib-gfx
+tonelib-jam
+tonelib-metal
 tonelib-noisereducer
 tonelib-tubewarmth
 tonelib-zoom

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -198,6 +198,9 @@ terraform
 texworks
 tidal-hifi
 tixati
+tonelib-bassdrive
+tonelib-noisereducer
+tonelib-tubewarmth
 tonelib-zoom
 tribler
 trivy

--- a/01-main/packages/tonelib-bassdrive
+++ b/01-main/packages/tonelib-bassdrive
@@ -1,0 +1,10 @@
+DEFVER=1
+get_website "https://www.tonelib.net/downloads.html"
+TLAPP="BassDrive"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(unroll_url "$(grep -o "https://www\.tonelib\.net/download/ToneLib-${TLAPP}[[:alpha:]]*-amd64\.deb" "${CACHE_FILE}")")"
+    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' )"
+fi
+PRETTY_NAME="ToneLib BassDrive"
+WEBSITE="https://tonelib.net"
+SUMMARY="Freeware Audio effect plugin."

--- a/01-main/packages/tonelib-gfx
+++ b/01-main/packages/tonelib-gfx
@@ -1,0 +1,10 @@
+DEFVER=1
+get_website "https://www.tonelib.net/downloads.html"
+TLAPP=$(echo ${APP^^} |cut -d-  -f2)
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(unroll_url "$(grep -o "https://www\.tonelib\.net/download/ToneLib-${TLAPP}[[:alpha:]]*-amd64\.deb" "${CACHE_FILE}")")"
+    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' )"
+fi
+PRETTY_NAME="ToneLib GFX"
+WEBSITE="https://tonelib.net"
+SUMMARY="A complete guitar studio in one app."

--- a/01-main/packages/tonelib-jam
+++ b/01-main/packages/tonelib-jam
@@ -1,0 +1,10 @@
+DEFVER=1
+get_website "https://www.tonelib.net/downloads.html"
+TLAPP="Jam"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(unroll_url "$(grep -o "https://www\.tonelib\.net/download/ToneLib-${TLAPP}[[:alpha:]]*-amd64\.deb" "${CACHE_FILE}")")"
+    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' )"
+fi
+PRETTY_NAME="ToneLib Jam"
+WEBSITE="https://tonelib.net"
+SUMMARY="The ultimate software dedicated to the beginner as well as the advanced guitar player."

--- a/01-main/packages/tonelib-metal
+++ b/01-main/packages/tonelib-metal
@@ -1,0 +1,10 @@
+DEFVER=1
+get_website "https://www.tonelib.net/downloads.html"
+TLAPP="Metal"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(unroll_url "$(grep -o "https://www\.tonelib\.net/download/ToneLib-${TLAPP}[[:alpha:]]*-amd64\.deb" "${CACHE_FILE}")")"
+    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' )"
+fi
+PRETTY_NAME="ToneLib Metal"
+WEBSITE="https://tonelib.net"
+SUMMARY="Ideal Amp Suite for Metal Guitar"

--- a/01-main/packages/tonelib-noisereducer
+++ b/01-main/packages/tonelib-noisereducer
@@ -1,0 +1,10 @@
+DEFVER=1
+get_website "https://www.tonelib.net/downloads.html"
+TLAPP="NoiseReducer"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(unroll_url "$(grep -o "https://www\.tonelib\.net/download/ToneLib-${TLAPP}[[:alpha:]]*-amd64\.deb" "${CACHE_FILE}")")"
+    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' )"
+fi
+PRETTY_NAME="ToneLib GFX"
+WEBSITE="https://tonelib.net"
+SUMMARY="Freeware Audio effect plugin."

--- a/01-main/packages/tonelib-tubewarmth
+++ b/01-main/packages/tonelib-tubewarmth
@@ -1,0 +1,10 @@
+DEFVER=1
+get_website "https://www.tonelib.net/downloads.html"
+TLAPP="TubeWarmth"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(unroll_url "$(grep -o "https://www\.tonelib\.net/download/ToneLib-${TLAPP}[[:alpha:]]*-amd64\.deb" "${CACHE_FILE}")")"
+    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' )"
+fi
+PRETTY_NAME="ToneLib TubeWarmth"
+WEBSITE="https://tonelib.net"
+SUMMARY="Freeware Audio effect plugin."

--- a/01-main/packages/tonelib-zoom
+++ b/01-main/packages/tonelib-zoom
@@ -1,0 +1,10 @@
+DEFVER=1
+get_website "https://www.tonelib.net/downloads.html"
+TLAPP="Zoom"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="https://www.tonelib.net/download/ToneLib-Zoom-amd64.deb"
+    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' )"
+fi
+PRETTY_NAME="ToneLib Zoom"
+WEBSITE="https://tonelib.net"
+SUMMARY="An easy-to-use application which allows you to see, change and save all the settings in your Zoom guitar pedal."


### PR DESCRIPTION
closes #596 

This add a number of ToneLib apps and audio effects plugins as requested.
Note that only ToneLib Zoom is not marked "experimental" for the native Ubuntu support. 
Good to see some audio plugins trying to support Linux natively.  This is one PR for the lot - naturally will split if preferred.


Commercial 

-   tonelib-gfx
-   tonelib-jam
-   tonelib-metal

Freeware
  - tonelib-bassdrive
  - tonelib-noisereducer
  - tonelib-tubewarmth
  - tonelib-zoom
