### PR TITLE
Added media-downloader

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -108,6 +108,7 @@ lutris
 mailspring
 master-pdf-editor-5
 mattermost-desktop
+media-downloader
 mediathekview
 mergerfs
 micro

--- a/01-main/packages/media-downloader
+++ b/01-main/packages/media-downloader
@@ -1,0 +1,14 @@
+DEFVER=1
+LOCAL IS_UBUNTU=""
+case ${UPSTREAM_ID} in #
+    ubuntu) IS_UBUNTU="x";;
+    *) IS_UBUNTU="";;
+esac
+if [ ! -z ${TRY_LTS} ]; then
+UPSTREAM_RELEASE=${UPSTREAM_RELEASE/22.10/${TRY_LTS}}
+fi
+ASC_KEY_URL="https://download.opensuse.org/repositories/home:obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/Release.key"
+APT_REPO_URL="http://download.opensuse.org/repositories/home:/obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/ /"
+PRETTY_NAME="Media Downloader"
+WEBSITE="https://github.com/mhogomchungu/media-downloader"
+SUMMARY="A Qt/C++ based GUI frontend to multiple CLI based tools that deal with downloading online media. yt-dlp CLI tool is the default supported tool and other tools can be added."

--- a/01-main/packages/media-downloader
+++ b/01-main/packages/media-downloader
@@ -4,10 +4,7 @@ case ${UPSTREAM_ID} in #
     ubuntu) IS_UBUNTU="x";;
     *) IS_UBUNTU="";;
 esac
-if [ ! -z ${TRY_LTS} ]; then
-UPSTREAM_RELEASE=${UPSTREAM_RELEASE/22.10/${TRY_LTS}}
-fi
-CODENAMES_SUPPORTED="stretch buster bullseye bionic focal jammy ${TRY_LTS/22.04/kinetic}"
+CODENAMES_SUPPORTED="stretch buster bullseye bionic focal jammy"
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/Release.key"
 APT_REPO_URL="http://download.opensuse.org/repositories/home:/obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/ /"
 PRETTY_NAME="Media Downloader"

--- a/01-main/packages/media-downloader
+++ b/01-main/packages/media-downloader
@@ -7,6 +7,7 @@ esac
 if [ ! -z ${TRY_LTS} ]; then
 UPSTREAM_RELEASE=${UPSTREAM_RELEASE/22.10/${TRY_LTS}}
 fi
+CODENAMES_SUPPORTED="stretch buster bullseye bionic focal jammy ${TRY_LTS/22.04/kinetic}"
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/Release.key"
 APT_REPO_URL="http://download.opensuse.org/repositories/home:/obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/ /"
 PRETTY_NAME="Media Downloader"


### PR DESCRIPTION
Closes #683 

Should work for Ubuntus and Debians.
No release yet for 22.10 
edit: removed the "try LTS" kludge as requested. 
