### PR TITLE
fix for spotify-client key rotation

### DIFF
--- a/01-main/packages/spotify-client
+++ b/01-main/packages/spotify-client
@@ -1,5 +1,5 @@
 DEFVER=2
-ASC_KEY_URL="https://download.spotify.com/debian/pubkey_5E3C45D7B312C643.gpg"
+ASC_KEY_URL="https://download.spotify.com/debian/pubkey_7A3A762FAFD4A51F.gpg"
 APT_REPO_URL="http://repository.spotify.com stable non-free"
 PRETTY_NAME="Spotify"
 WEBSITE="https://www.spotify.com/"


### PR DESCRIPTION
Spotify have rotated the package signing key. 
fixes #730 