### PR TITLE
Fix insync key removal using keyID fetch

### DIFF
--- a/01-main/packages/insync
+++ b/01-main/packages/insync
@@ -1,8 +1,5 @@
 DEFVER=1
-# key gone from website
-# this key is not enough to install but at least keeps _us_ happy
-# # while they sort themselves out
-GPG_KEY_URL="https://d2t3ff60b2tol4.cloudfront.net/services@insynchq.com.gpg.key"
+GPG_KEY_ID="A684470CACCAF35C"
 APT_REPO_URL="http://apt.insync.io/${UPSTREAM_ID} ${UPSTREAM_CODENAME} non-free contrib"
 PRETTY_NAME="Insync"
 WEBSITE="https://www.insynchq.com/"

--- a/01-main/packages/insync
+++ b/01-main/packages/insync
@@ -1,7 +1,8 @@
 DEFVER=1
-if [ "${ACTION}" != "prettylist" ]; then
-    ASC_KEY_URL="$(curl -s https://www.insynchq.com/downloads | grep gpgkey | cut -d'=' -f2)"
-fi
+# key gone from website
+# this key is not enough to install but at least keeps _us_ happy
+# # while they sort themselves out
+GPG_KEY_URL="https://d2t3ff60b2tol4.cloudfront.net/services@insynchq.com.gpg.key"
 APT_REPO_URL="http://apt.insync.io/${UPSTREAM_ID} ${UPSTREAM_CODENAME} non-free contrib"
 PRETTY_NAME="Insync"
 WEBSITE="https://www.insynchq.com/"


### PR DESCRIPTION
Requires #741 to be merged but then fetches current key correctly.
Existing users with the old key will need to remove it (or uninstall/re-install may do that for them)
