### PR TITLE
Fixes 658 - add Trilium Notes

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -213,6 +213,7 @@ tonelib-noisereducer
 tonelib-tubewarmth
 tonelib-zoom
 tribler
+trilium
 trivy
 typora
 ubuntu-make

--- a/01-main/packages/trilium
+++ b/01-main/packages/trilium
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "zadam/trilium" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
+fi
+PRETTY_NAME="Trilium Notes"
+WEBSITE="https://github.com/zadam/trilium/"
+SUMMARY="Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases."


### PR DESCRIPTION
Fixes [#658](https://github.com/wimpysworld/deb-get/issues/658)
Add support for installing Trilium Notes.