### PR TITLE
Add JupyterLab Desktop package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -94,6 +94,7 @@ iriunwebcam
 jabref
 jami
 jellyfin
+jupyterlab-desktop
 kapacitor
 kdiskmark
 keepassxc

--- a/01-main/packages/jupyterlab-desktop
+++ b/01-main/packages/jupyterlab-desktop
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "jupyterlab/jupyterlab-desktop" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*.deb" "${CACHE_FILE}" | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
+fi
+PRETTY_NAME="JupyterLab Desktop"
+WEBSITE="https://github.com/jupyterlab/jupyterlab-desktop"
+SUMMARY="JupyterLab desktop application, based on Electron"


### PR DESCRIPTION
Closes #742 

Tested in 99-local.d and it works (on ubuntu 22.10)