### PR TITLE
Rename misnamed application

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -181,7 +181,7 @@ slack-desktop
 sleek
 smartgit
 softmaker-office-2021
-sound-switcher-indicator
+indicator-sound-switcher
 soundux
 spotify-client
 standard-notes

--- a/01-main/packages/indicator-sound-switcher
+++ b/01-main/packages/indicator-sound-switcher
@@ -3,3 +3,4 @@ PPA="ppa:yktooo/ppa"
 PRETTY_NAME="Sound Switcher Indicator"
 WEBSITE="https://yktoo.com/en/software/sound-switcher-indicator/#software-downloads"
 SUMMARY="Sound input/output selector indicator for Linux."
+


### PR DESCRIPTION
fix: sound-switcher-indicator application is actually called indicator-sound-switcher

correction to align the file naming with the actual package naming
