### PR TITLE
Add installer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ release pages.
 Use `deb-get` to install `deb-get`.
 
 ```bash
-sudo apt install curl
+sudo apt install curl lsb-release wget
 curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
 ```
 


### PR DESCRIPTION
Ubuntu Desktop may already include package `lsb-release` and `wget`. They are not installed in the official `ubuntu:20.04` container image on DockerHub.