### PR TITLE
Handle Sourceforge params in unroll_url()

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -146,9 +146,13 @@ function create_etc_dir() {
     ${ELEVATE} chmod 755 "${ETC_DIR}" 2>/dev/null
 }
 
+
 function unroll_url() {
-    curl -w "%{url_effective}\n" -I -L -s -S "${1}" -o /dev/null
+    # Sourceforge started adding parameters
+    local TRIM_URL="$(curl -w "%{url_effective}\n" -I -L -s -S "${1}" -o /dev/null)"
+    echo "${TRIM_URL/\.deb*/.deb}"
 }
+
 
 function get_github_releases() {
     METHOD="github"


### PR DESCRIPTION
fixes #754 