### PR TITLE
Virtualbox is not available for non-LTS releases

### DIFF
--- a/01-main/packages/virtualbox-6.1
+++ b/01-main/packages/virtualbox-6.1
@@ -1,4 +1,5 @@
 DEFVER=1
+CODENAMES_SUPPORTED="buster bullseye stretch bionic focal jammy"
 ASC_KEY_URL="https://www.virtualbox.org/download/oracle_vbox_2016.asc"
 APT_REPO_URL="https://download.virtualbox.org/virtualbox/debian ${UPSTREAM_CODENAME} contrib"
 APT_REPO_OPTIONS="arch=amd64"

--- a/01-main/packages/virtualbox-7.0
+++ b/01-main/packages/virtualbox-7.0
@@ -1,4 +1,5 @@
 DEFVER=1
+CODENAMES_SUPPORTED="buster bullseye bionic focal jammy"
 ASC_KEY_URL="https://www.virtualbox.org/download/oracle_vbox_2016.asc"
 APT_REPO_URL="https://download.virtualbox.org/virtualbox/debian ${UPSTREAM_CODENAME} contrib"
 APT_REPO_OPTIONS="arch=amd64"


### PR DESCRIPTION
This is the real solution for #767 

It needs checking/implementing for these too:

```
grep -L CODENAMES_SUPPORTED $(grep -l  UPSTREAM_CODENAME  $(grep -l APT 01-main/packages/*))
01-main/packages/azure-cli
01-main/packages/docker-ce
01-main/packages/dropbox
01-main/packages/insync
01-main/packages/jellyfin
01-main/packages/nomad
01-main/packages/tailscale
01-main/packages/tarsnap
01-main/packages/terraform
01-main/packages/ungoogled-chromium
01-main/packages/waydroid
01-main/packages/weechat
```

Update: all above checked and those that can be seen to be restricted to some releases (`azure-cli`) or need mapping (`waydroid`) have been addressed in #770