### PR TITLE
stop ferdium getting nightlies

### DIFF
--- a/01-main/packages/ferdium
+++ b/01-main/packages/ferdium
@@ -1,8 +1,9 @@
 DEFVER=1
-get_github_releases "ferdium/ferdium-app"
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "ferdium/ferdium-app" latest
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
+    URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -v -e nightly -e beta | head -n1 | cut -d'"' -f4)"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
 fi
 PRETTY_NAME="Ferdium"
 WEBSITE="https://ferdium.org/"


### PR DESCRIPTION
or betas.  Adding latest to the github sorts it.
So does grep -v
Also the version string needed rework

Closes #772 