### PR TITLE
add PDFsam Basic

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -147,6 +147,7 @@ p3x-onenote
 pandoc
 papirus-icon-theme
 #parsec
+pdfsam-basic
 peazip
 #picocrypt
 plexmediaserver

--- a/01-main/packages/pdfsam-basic
+++ b/01-main/packages/pdfsam-basic
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_github_releases "torakiki/pdfsam" latest
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -v -e nightly -e beta -e alpha| head -n1 | cut -d'"' -f4)"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
+fi
+PRETTY_NAME="PDFsam Basic"
+WEBSITE="https://pdfsam.org/"
+SUMMARY="PDFsam (PDF Split And Merge) Basic is a free and open source, multi-platform software designed to extract pages, split, merge, mix and rotate PDF files."


### PR DESCRIPTION
Closes #710 

Note the free app is called `pdfsam-basic`

A separate licensable (free trial) Electron-based product (PDFsam Visual) is also available but will need its own PR (ready and tested if wanted)

Also their chosen style is indeed `PDFsam` and not ~~`PDFSam`~~

```
deb-get show pdfsam-basic pdfsam-visual |grep -v -e '\['
PDFsam Basic
  Package:	pdfsam-basic
  Repository:	90-contribs
  Updater:	deb-get
  Installed:	5.0.3-1
  Published:	5.0.3
  Architecture:	amd64
  Download:	https://github.com/torakiki/pdfsam/releases/download/v5.0.3/pdfsam_5.0.3-1_amd64.deb
  Website:	https://pdfsam.org/
  Summary:	PDFsam (PDF Split And Merge) Basic is a free and open source, multi-platform software designed to extract pages, split, merge, mix and rotate PDF files.
PDFsam Visual
  Package:	pdfsam-visual
  Repository:	90-contribs
  Updater:	deb-get
  Installed:	4.3.0
  Published:	4.3.0
  Architecture:	amd64
  Download:	https://github.com/torakiki/pdfsam-visual-public/releases/download/v4.3.0/pdfsam-visual_4.3.0_amd64.deb
  Website:	https://pdfsam.org/
  Summary:	PDFsam Visual is a powerful tool to visually combine PDF files, rearrange pages, compress, extract or delete pages, split, merge, rotate, encrypt, decrypt, repair, resize pages, extract text, convert to grayscale, crop PDF files.
```
