### PR TITLE
tests need to authenticate too

### DIFF
--- a/.github/workflows/tests-01-main.yml
+++ b/.github/workflows/tests-01-main.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           chmod a+x ./deb-get
           export DEBIAN_FRONTEND=noninteractive
+          export DEBGET_TOKEN=${{ secrets.GITHUB_TOKEN }}
           set -x
           APPS="$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^01-main/packages/" | sed "s|^01-main/packages/||")"
           SUPPORTED="$(./deb-get list --raw)"

--- a/01-main/packages/fastfetch
+++ b/01-main/packages/fastfetch
@@ -1,4 +1,5 @@
 DEFVER=1
+# NOOP edit to provke PoC test run
 get_github_releases "LinusDierheimer/fastfetch" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*Linux\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)


### PR DESCRIPTION
The workflows are generating warnings/empty files for all the github-sourced cache files.