### PR TITLE
add i3

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -81,6 +81,7 @@ heroic
 homeassistant-supervised
 hugo
 hyper
+i3
 igdm
 #igdm-pro
 influxdb

--- a/01-main/packages/i3
+++ b/01-main/packages/i3
@@ -1,0 +1,10 @@
+DEFVER=2
+# Debian should not use this repo
+# See https://i3wm.org/docs/repositories.html
+CODENAMES_SUPPORTED="bionic focal jammy kinetic"
+GPG_KEY_ID="E3CA1A89941C42E6"
+APT_REPO_URL="http://debian.sur5r.net/i3/ ${UPSTREAM_CODENAME} universe"
+APT_REPO_OPTIONS="arch=amd64"
+PRETTY_NAME="i3"
+WEBSITE="https://i3wm.org/"
+SUMMARY="i3 window manager - Stable release"


### PR DESCRIPTION
Closes #609 

Note the development version mentioned in #609 can be used to override the stable version if desired by using an extrepo or `/etc/deb-get/99-local.d/` 

Now we can use a keyserver the stable version is possible without having to use the signing key .deb or the tarfile with the key in.

They recommend Debian users to avoid their repo and to prefer debian testing. (noted in the package definition).