### PR TITLE
tweak Tonelib-Bassdrive wrong version

### DIFF
--- a/01-main/packages/tonelib-bassdrive
+++ b/01-main/packages/tonelib-bassdrive
@@ -3,7 +3,7 @@ get_website "https://www.tonelib.net/downloads.html"
 TLAPP="BassDrive"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(unroll_url "$(grep -o "https://www\.tonelib\.net/download/ToneLib-${TLAPP}[[:alpha:]]*-amd64\.deb" "${CACHE_FILE}")")"
-    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' )"
+    VERSION_PUBLISHED="$(echo $(grep  -A4 "ToneLib ${TLAPP}" ${CACHE_FILE} |grep Version |grep -o "[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*") | sed 's/\./-/2' | sed 's/.2/.1/' )"
 fi
 PRETTY_NAME="ToneLib BassDrive"
 WEBSITE="https://tonelib.net"


### PR DESCRIPTION
They send 1.1 but purport to send 1.2.
No reponse from upstream so this fixes false updates