### PR TITLE
add nuclear

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -132,6 +132,7 @@ nextcloud-desktop
 nomad
 nordvpn
 notable
+nuclear
 obs-cli
 obsidian
 obs-studio

--- a/01-main/packages/nuclear
+++ b/01-main/packages/nuclear
@@ -4,7 +4,8 @@ DEFVER=1
 get_github_releases "nukeop/nuclear"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)"
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
+    VERSION_PUBLISHED="$(grep published_at "${CACHE_FILE}" | head -n1|cut -d'"' -f4)-$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
+    VERSION_PUBLISHED="$(echo "${VERSION_PUBLISHED}" | sed "s/\://g")"
 fi
 PRETTY_NAME="Nuclear"
 WEBSITE="https://nuclear.js.org/"

--- a/01-main/packages/nuclear
+++ b/01-main/packages/nuclear
@@ -1,0 +1,11 @@
+DEFVER=1
+# they have no release, all are set as pre-release
+# using "latest" would return nothing
+get_github_releases "nukeop/nuclear"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
+fi
+PRETTY_NAME="Nuclear"
+WEBSITE="https://nuclear.js.org/"
+SUMMARY="Streaming music player that finds free music for you."


### PR DESCRIPTION
Closes #697 
Their releases are all pre-release. Last release with release like name was v0.6.17 in 2021 (but still pre-release) and since then they tag with git sha.
Even the latest deb is identified in dpkg as 0.6.17 which has an unfortunate result of

Nuclear
  Package:	nuclear
  Repository:	01-main
  Updater:	deb-get
  Installed:	0.6.17                                   - identifies as 0.6.17 (from 2021) 
  Published:	fd06a3                                 - this is really installed, from 2023
  Architecture:	amd64
  Download:	https://github.com/nukeop/nuclear/releases/download/fd06a3/nuclear-fd06a3.deb
  Website:	https://nuclear.js.org/
  Summary:	Streaming music player that finds free music for you.
