### PR TITLE
Fix: jellyfin-media-player definition made to work on Linux Mint

### DIFF
--- a/01-main/packages/jellyfin-media-player
+++ b/01-main/packages/jellyfin-media-player
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64"
 CODENAMES_SUPPORTED="bookworm bullseye kinetic jammy focal"
 get_github_releases "jellyfin/jellyfin-media-player" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}-${OS_CODENAME}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+    URL=$(grep "browser_download_url.*${HOST_ARCH}-${UPSTREAM_CODENAME}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
 fi
 PRETTY_NAME="Jellyfin Media Player"


### PR DESCRIPTION
Use UPSTREAM_CODENAME so as to work on Mint and friends.

Fixes #822