### PR TITLE
Fix downloads and website urls for Rstudio and Rstudio-server

### DIFF
--- a/01-main/packages/rstudio
+++ b/01-main/packages/rstudio
@@ -3,7 +3,7 @@ get_website "https://posit.co/download/rstudio-desktop/"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${UPSTREAM_CODENAME}" in
         focal|buster|bullseye)
-            URL="$( grep -e "bionic/.*amd64.deb" "${CACHE_FILE}" | grep -v "tar.gz" | head -n1 | cut -d'"' -f4)"
+            URL="$( grep -e "focal/.*amd64.deb" "${CACHE_FILE}" | grep -v "tar.gz" | head -n1 | cut -d'"' -f4)"
             ;;
         *)
             URL="$( grep -e "jammy/.*amd64.deb" "${CACHE_FILE}" | grep -v "tar.gz" | head -n1 | cut -d'"' -f4)"
@@ -12,6 +12,6 @@ if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'-' -f2-3 | tr - +)"
 fi
 PRETTY_NAME="RStudio"
-WEBSITE="https://www.rstudio.com/"
+WEBSITE="https://posit.co/"
 #https://posit.co/products/open-source/rstudio/
 SUMMARY="Professional software for data science teams."

--- a/01-main/packages/rstudio-server
+++ b/01-main/packages/rstudio-server
@@ -3,7 +3,7 @@ get_website "https://posit.co/download/rstudio-server/"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${UPSTREAM_CODENAME}" in
         focal|buster|bullseye)
-            URL="$( grep -o -E "wget.*bionic.*amd64\.deb" "${CACHE_FILE}" | cut -d' ' -f2)"
+            URL="$( grep -o -E "wget.*focal.*amd64\.deb" "${CACHE_FILE}" | cut -d' ' -f2)"
             ;;
         *)
             URL="$( grep -o -E "wget.*jammy.*amd64\.deb" "${CACHE_FILE}" | cut -d' '  -f2)"
@@ -12,6 +12,6 @@ if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED="$(echo "${URL}" |  grep -E -o '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\-[[:digit:]]+' | tr - +)"
 fi
 PRETTY_NAME="RStudio Server"
-WEBSITE="https://www.rstudio.com/"
+WEBSITE="https://posit.co"
 #https://posit.co/products/open-source/rstudio/
 SUMMARY="Professional software for data science teams."


### PR DESCRIPTION
Hello,

URLs for downloading Rstudio and Rstudio server have changed. Updating both repositories to fix this.
I also updated the main website URL from rstudio to posit (new company name).

Tested on my laptop with Ubuntu 20.04. 

Thanks for maintaining deb-get!
Arnaud