### PR TITLE
Renamed ms-office-electron as project renamed

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -129,7 +129,8 @@ minigalaxy
 minikube
 motrix
 mpdevil
-ms-office-electron
+#ms-office-electron
+ms-365-electron
 mullvad-vpn
 nala
 nala-legacy

--- a/01-main/packages/ms-365-electron
+++ b/01-main/packages/ms-365-electron
@@ -1,9 +1,9 @@
 DEFVER=1
-get_github_releases "agam778/MS-Office-Electron" "latest"
+get_github_releases "agam778/MS-365-Electron" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
 fi
 PRETTY_NAME="Office 365"
-WEBSITE="https://agam778.github.io/MS-Office-Electron/"
-SUMMARY="A Microsoft Office Online Desktop Client made with Electron."
+WEBSITE="https://agam778.github.io/MS-365-Electron/"
+SUMMARY="An Unofficial Microsoft Office 365 Desktop Client made with Electron."


### PR DESCRIPTION
Deprecated the old name as existing users will need to install the replacement and remove the old one

Closes #844 