### PR TITLE
fix installing rustdesk

### DIFF
--- a/01-main/packages/rustdesk
+++ b/01-main/packages/rustdesk
@@ -1,5 +1,5 @@
 DEFVER=1
-ARCHS_SUPPORTED="amd64 armhf"
+ARCHS_SUPPORTED="amd64 armv7 aarch64"
 get_github_releases "rustdesk/rustdesk" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${HOST_ARCH}" in


### PR DESCRIPTION
the architectures rustdesk support changed, which broke our check causing the install to fail
fixes #861 