### PR TITLE
Remove Exodus wallet.

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -57,6 +57,7 @@ dustracing2d
 element-desktop
 enpass
 exifcleaner
+#exodus
 expressvpn
 fastfetch
 fd

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -56,7 +56,6 @@ duf
 dustracing2d
 element-desktop
 enpass
-exodus
 exifcleaner
 expressvpn
 fastfetch

--- a/01-main/packages/exodus
+++ b/01-main/packages/exodus
@@ -1,9 +1,0 @@
-DEFVER=1
-get_website "https://www.exodus.com/download/"
-if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED="$(sed "s|.*https://downloads\.exodus\.com/releases/hashes-exodus-||" "${CACHE_FILE}" | sed "s/\.txt.*//")"
-    URL="https://downloads.exodus.com/releases/exodus-linux-x64-${VERSION_PUBLISHED}.deb"
-fi
-PRETTY_NAME="Exodus"
-WEBSITE="https://exodus.com/"
-SUMMARY="Bitcoin & Crypto Wallet."


### PR DESCRIPTION
They moved download link behind a button press. Original download link has been returning 403 for some time.