### PR TITLE
latest onlyoffice-desktopeditors release missing assets

### DIFF
--- a/01-main/packages/onlyoffice-desktopeditors
+++ b/01-main/packages/onlyoffice-desktopeditors
@@ -1,5 +1,5 @@
 DEFVER=1
-get_github_releases "ONLYOFFICE/DesktopEditors" "latest"
+get_github_releases "ONLYOFFICE/DesktopEditors" 
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | grep -v help | cut -d'"' -f4)"
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"


### PR DESCRIPTION
Still waiting for them to package most of the assets.
The lack of a .deb on the latest release breaks us updating so this tweak gets us the latest released deb at the expense of a larger cache.