### PR TITLE
Fix onlyoffice delayed packaging

### DIFF
--- a/01-main/packages/onlyoffice-desktopeditors
+++ b/01-main/packages/onlyoffice-desktopeditors
@@ -1,7 +1,7 @@
 DEFVER=1
-get_github_releases "ONLYOFFICE/DesktopEditors" "latest"
+get_github_releases "ONLYOFFICE/DesktopEditors" 
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | grep -v help | cut -d'"' -f4)"
+    URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | grep -v help | head -n1 | cut -d'"' -f4)"
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
 fi
 PRETTY_NAME="ONLYOFFICE Desktop Editors"


### PR DESCRIPTION
Upstream delayed packaging of latest release assets breaks our updating. This gets the latest release deb.
