### PR TITLE
Remove codenames from mdview package def

### DIFF
--- a/01-main/packages/mdview
+++ b/01-main/packages/mdview
@@ -1,6 +1,5 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-CODENAMES_SUPPORTED="buster bullseye bookworm sid focal jammy kinetic lunar"
 get_github_releases "mapitman/mdview" "latest"
 if [ "${ACTION}" != prettylist ]; then
     URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)"


### PR DESCRIPTION
The example I followed when I initially added this package listed the codenames. This package has no dependencies, so it will work with any Debian or Ubuntu version.

Fixes #927