### PR TITLE
Add jc package

### DIFF
--- a/01-main/packages/jc
+++ b/01-main/packages/jc
@@ -1,0 +1,12 @@
+DEFVER=1
+ARCHS_SUPPORTED='amd64'
+get_github_releases 'kellyjonbrazil/jc' 'latest'
+if [ "${ACTION}" != prettylist ]; then
+    URL=$(grep -m1 "browser_download_url.*${HOST_ARCH}.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
+    VERSION_PUBLISHED=$(sed -n -e 's@.*/download/v\([^/]*\)/.*@\1@p' <<<"$URL")
+    printf %s\\n "$VERSION_PUBLISHED" >/tmp/dg.log
+fi
+EULA=''
+PRETTY_NAME='jc'
+WEBSITE='https://github.com/kellyjonbrazil/jc'
+SUMMARY='JSON CLI output utility'

--- a/01-main/packages/jc
+++ b/01-main/packages/jc
@@ -2,9 +2,10 @@ DEFVER=1
 ARCHS_SUPPORTED='amd64'
 get_github_releases 'kellyjonbrazil/jc' 'latest'
 if [ "${ACTION}" != prettylist ]; then
-    URL=$(grep -m1 "browser_download_url.*${HOST_ARCH}.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
-    VERSION_PUBLISHED=$(sed -n -e 's@.*/download/v\([^/]*\)/.*@\1@p' <<<"$URL")
-    printf %s\\n "$VERSION_PUBLISHED" >/tmp/dg.log
+    URL=$(grep -m1 -o "\"browser_download_url\":[[:space:]]*\"[^\"]*${HOST_ARCH}[^\"]*\.deb" "${CACHE_FILE}")
+    URL=${URL##*\"}
+    VERSION_PUBLISHED=${URL##*/download/v}
+    VERSION_PUBLISHED=${VERSION_PUBLISHED%%/*}
 fi
 EULA=''
 PRETTY_NAME='jc'


### PR DESCRIPTION
Besides adding [jc](https://github.com/kellyjonbrazil/jc), this PR showcases a cleaner way to extract URL / version from the GH-release JSON file; the code is explained in the last commit. This method also cuts down on external shell calls (a single `grep`, down from 5 external utility calls for most packages); the rest is done via shell string-ops.