### PR TITLE
Update sunshine codenames to include debian bookworm

### DIFF
--- a/01-main/packages/sunshine
+++ b/01-main/packages/sunshine
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-CODENAMES_SUPPORTED="bullseye focal jammy"
+CODENAMES_SUPPORTED="bookworm bullseye focal jammy"
 SUNSHINE_RELEASE="${UPSTREAM_RELEASE}"
 if [ "${UPSTREAM_ID}" == debian ]; then
     SUNSHINE_RELEASE=$UPSTREAM_CODENAME


### PR DESCRIPTION
Sunshine releases now contain debs for Debian Bookworm:

https://github.com/LizardByte/Sunshine/releases/tag/v0.21.0

I tested this by making the same change to `/etc/deb-get/01-main.d/sunshine` and successfully running `deb-get install sunshine` on Debian Bookworm.

Would be nice to be able to test changes directly from the git checkout.
