### PR TITLE
Add OpenTofu

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -250,6 +250,7 @@ thinlinc-client
 thorium-browser
 tidal-hifi
 tixati
+tofu
 tonelib-bassdrive
 tonelib-gfx
 tonelib-jam

--- a/01-main/packages/tofu
+++ b/01-main/packages/tofu
@@ -1,0 +1,9 @@
+DEFVER=1
+ARCHS_SUPPORTED=amd64 arm64 armhf
+ASC_KEY_URL="https://packages.opentofu.org/opentofu/tofu/gpgkey"
+APT_LIST_NAME="opentofu"
+APT_REPO_URL="https://packages.opentofu.org/opentofu/tofu/any/ any main"
+APT_REPO_OPTIONS="arch=${HOST_ARCH}"
+PRETTY_NAME="OpenTofu"
+WEBSITE="https://opentofu.org/"
+SUMMARY="The open source infrastructure as code tool."


### PR DESCRIPTION
Closes #880

Following the contrib guide, I didn't add the tool name to the list/manifest.

I've tested this with success on an Ubuntu 23.10 amd64 system.