### PR TITLE
Fix croc

### DIFF
--- a/01-main/packages/croc
+++ b/01-main/packages/croc
@@ -1,5 +1,5 @@
 DEFVER=1
-get_github_releases "schollz/croc" "latest"
+get_github_releases "schollz/croc" 
 
 if [ "${ACTION}" != "prettylist" ]; then
   case ${HOST_ARCH} in


### PR DESCRIPTION
`croc` is not producing deb assets for all releases.

If they don't intend to resume producing debs we will need to deprecate `croc`.
This gets the most recent deb for now and there's nothing obviously significant in subsequent changelogs beyond dependabot, CI tweaks etc.

Closes #997 