### PR TITLE
fix fastfetch

### DIFF
--- a/01-main/packages/fastfetch
+++ b/01-main/packages/fastfetch
@@ -1,9 +1,20 @@
 DEFVER=1
-get_github_releases "LinusDierheimer/fastfetch" "latest"
+get_github_releases "fastfetch-cli/fastfetch"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*Linux\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+
+case $(UPSTREAM_CODENAME) in
+    buster|bullseye|focal) 
+        URL=$(grep "browser_download_url.*Linux\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+        ARCHS_SUPPORTED="amd64"
+        ;;
+    *)
+        URL=$(grep "browser_download_url.*linux-${HOST_CPU}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+        ARCHS_SUPPORTED="amd64 arm64"
+        ;;
+esac
+
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
 fi
 PRETTY_NAME="FastFetch"
-WEBSITE="https://github.com/LinusDierheimer/fastfetch"
+WEBSITE="https://github.com/fastfetch-cli/fastfetch"
 SUMMARY="Fastfetch is a neofetch-like tool for fetching system information and displaying them in a pretty way. It is written in pure c, with performance and customizability in mind."


### PR DESCRIPTION
latest release no longer supports debian <=11 or focal also release naming has changed, repository moved and re-directed, and ARM build added


Fixes #1008 



Co-authored-by: mralusw  <mralusw@users.noreply.github.com>

