### PR TITLE
Tweak firefox to mimic other firefox packages

### DIFF
--- a/01-main/packages/firefox
+++ b/01-main/packages/firefox
@@ -1,6 +1,11 @@
 DEFVER=1
-CODENAMES_SUPPORTED="mantic lunar jammy focal bionic xenial"
+# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
+ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
+# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic"
+APT_LIST_NAME="mozilla.org"
 PPA="ppa:mozillateam/ppa"
-PRETTY_NAME="firefox"
-WEBSITE="https://www.mozilla.org/firefox/enterprise/"
-SUMMARY="Firefox Stable Release."
+PRETTY_NAME="Firefox"
+WEBSITE="https://www.mozilla.org/firefox/"
+SUMMARY="Firefox web browser (stable release)."

--- a/01-main/packages/firefox
+++ b/01-main/packages/firefox
@@ -4,7 +4,7 @@ ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
 # focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
 CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic"
-APT_LIST_NAME="mozilla.org"
+APT_LIST_NAME="ppa.mozilla.org"
 PPA="ppa:mozillateam/ppa"
 PRETTY_NAME="Firefox"
 WEBSITE="https://www.mozilla.org/firefox/"


### PR DESCRIPTION
Tested and working in Ubuntu 23.10
Mostly cosmetic, but bionic and xenial aren't listed as supported in
https://github.com/wimpysworld/deb-get/blob/main/EXTREPO.md#the-package-definition-files
