### PR TITLE
Tweak firefox-esr to mimic other firefox packages

### DIFF
--- a/01-main/packages/firefox-esr
+++ b/01-main/packages/firefox-esr
@@ -1,5 +1,11 @@
 DEFVER=1
+# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
+ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
+# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic"
+APT_LIST_NAME="mozilla.org"
 PPA="ppa:mozillateam/ppa"
 PRETTY_NAME="Firefox ESR"
 WEBSITE="https://www.mozilla.org/firefox/enterprise/"
-SUMMARY=" Firefox Extended Support Release."
+SUMMARY=" Firefox web browser (extended support release)."

--- a/01-main/packages/firefox-esr
+++ b/01-main/packages/firefox-esr
@@ -4,7 +4,7 @@ ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
 # focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
 CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic"
-APT_LIST_NAME="mozilla.org"
+APT_LIST_NAME="ppa.mozilla.org"
 PPA="ppa:mozillateam/ppa"
 PRETTY_NAME="Firefox ESR"
 WEBSITE="https://www.mozilla.org/firefox/enterprise/"


### PR DESCRIPTION
Mostly cosmetic changes, but bionic and xenial aren't listed as supported in
https://github.com/wimpysworld/deb-get/blob/main/EXTREPO.md#the-package-definition-files

Tested and working in Ubuntu 23.10

I was actually able to install all five firefox versions at the same time. Unfortunately, the desktop names don't identify each version properly:
![Screenshot_20240217_071549](https://github.com/wimpysworld/deb-get/assets/220772/22e38b2f-c8f6-4618-8d84-4061a9517045)
