### PR TITLE
battery-monitor: move to mamolinux/battery-monitor

### DIFF
--- a/01-main/packages/battery-monitor
+++ b/01-main/packages/battery-monitor
@@ -1,10 +1,10 @@
 DEFVER=1
-CODENAMES_SUPPORTED="focal jammy kinetic"
-get_github_releases "hsbasu/battery-monitor" "latest"
+CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic"
+get_github_releases "mamolinux/battery-monitor" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)"
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
+    VERSION_PUBLISHED="$(cut -d'/' -f8 <<<"${URL}")"
 fi
 PRETTY_NAME="Battery Monitor"
-WEBSITE="https://github.com/hsbasu/battery-monitor/"
+WEBSITE="https://github.com/mamolinux/battery-monitor/"
 SUMMARY="An X-platform utility tool developed on Python, notifies about charging, discharging, and critically low battery state of the battery on laptop."


### PR DESCRIPTION
Fixes
```
[*] WARNING! Cached file /var/cache/deb-get/battery-monitor.json is empty or missing.
```