### PR TITLE
Add google-chrome-beta

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -86,6 +86,7 @@ gitkraken
 gitter
 glow
 google-chat-electron
+google-chrome-beta
 google-chrome-stable
 google-cloud-cli
 google-earth-pro-stable

--- a/01-main/packages/google-chrome-beta
+++ b/01-main/packages/google-chrome-beta
@@ -1,0 +1,9 @@
+DEFVER=1
+ASC_KEY_URL="https://dl.google.com/linux/linux_signing_key.pub"
+APT_LIST_NAME="google-chrome"
+APT_REPO_URL="https://dl.google.com/linux/chrome/deb/ stable main"
+APT_REPO_OPTIONS="arch=amd64"
+EULA="By downloading Chrome, you agree to the Google Terms of Service and Chrome and Chrome OS Additional Terms of Service\n - https://policies.google.com/terms\n - https://www.google.co.uk/intl/en/chrome/terms/"
+PRETTY_NAME="Google Chrome Beta"
+WEBSITE="https://www.google.com/chrome/beta/"
+SUMMARY="Fast, Secure Browser from Google (Beta Release)."

--- a/01-main/packages/google-chrome-beta
+++ b/01-main/packages/google-chrome-beta
@@ -1,4 +1,5 @@
 DEFVER=1
+ARCHS_SUPPORTED="amd64"
 ASC_KEY_URL="https://dl.google.com/linux/linux_signing_key.pub"
 APT_LIST_NAME="google-chrome"
 APT_REPO_URL="https://dl.google.com/linux/chrome/deb/ stable main"


### PR DESCRIPTION
All three versions installed OK on Ubuntu 23.10:

![Screenshot_20240218_073959-1](https://github.com/wimpysworld/deb-get/assets/220772/787be71d-20fa-4f41-ba7f-dbb066298f45)
