### PR TITLE
01-main: + ripgrep

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -207,6 +207,7 @@ rambox
 rclone
 resilio-sync
 retroarch
+ripgrep
 rocketchat
 rpi-imager
 rstudio

--- a/01-main/packages/ripgrep
+++ b/01-main/packages/ripgrep
@@ -1,0 +1,20 @@
+DEFVER=1
+ARCHS_SUPPORTED='amd64'
+SUMMARY='ripgrep recursively searches directories for a regex pattern while respecting your gitignore'
+EULA=''
+
+pkg_ripgrep() {
+  local GH_OWNER_REPO='BurntSushi/ripgrep'
+  local GH_REPO=${GH_OWNER_REPO##*/}
+  local DEB_PKGNAME=$GH_REPO
+  PRETTY_NAME=$GH_REPO
+  WEBSITE=https://github.com/$GH_OWNER_REPO
+  get_github_releases "$GH_OWNER_REPO" latest
+  if [ "${ACTION}" != prettylist ]; then
+      URL=$(grep -m1 -o "\"browser_download_url\":[[:space:]]*\"[^\"]*/${DEB_PKGNAME}_[^/\"]*_${HOST_ARCH}\.deb\"" "${CACHE_FILE}")
+      URL=${URL%\"}; URL=${URL##*\"}
+      local DEB_FILENAME=${URL##*/}
+      VERSION_PUBLISHED=${DEB_FILENAME#*_}; VERSION_PUBLISHED=${VERSION_PUBLISHED%%_*}
+  fi
+}
+pkg_ripgrep


### PR DESCRIPTION
Compared to my other package contributions,
* DRY, so other packages can reuse the template with as few changes as possible: everything is inferred from `GH_OWNER_REPO`, `SUMMARY` and `DEB_PKGNAME`. `SUMMARY` is not available from the cached json, and `DEB_PKGNAME` could presumably be different from the repo name (also, a repo can release multiple packages resulting in multiple debs for the same host architecture, e.g. `pkg-common`, `pkg-full`, `pkg-tiny` etc)
* custom variables are local to a `pkg_<NAME>` function so as not to pollute global namespace and avoid collisions with other packages / future `DEB_GET` mechanisms
* `VERSION_PUBLISHED` is inferred from the `*.deb` filename, as release versions / tags in the URL (which I've used previously) don't necessarily match that the `.deb` version

## Discussion

At some point I'd like to propose standardizing `get_github_url()`, a function that sets the `URL` variable; the most commonly used mechanism of `grep ... head ... cut` is somewhat haphazard and also causes at least two unnecessary `fork()`'/`exec()`'s per package. These don't matter compared to network access, but a lot of `deb_get` ops involve cached files without any network updates.

I'm still using a single `grep -m1 -o`, but I think it's actually possible to read the cached file into a string and search with `bash` regexes, without any external utilities at all, and without subshell-ing. Such an optimization would only change the proposed `get_github_url` function.