### PR TITLE
check if command is actually running in the background

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -640,19 +640,27 @@ function refresh_supported_cache_lists() {
     # WARN: this function must run in a subshell
     local lockfile=${CACHE_DIR}/updating_supported.lock
     if [ -f "$lockfile" ]; then
-        fancy_message warn "Cannot update cache of supported apps: $lockfile found (job still running?)"
-        return 0
-    else
-        trap "trap - EXIT; ${ELEVATE} rm -f \"$lockfile\"" EXIT
-        ${ELEVATE} touch "$lockfile"
-        ${ELEVATE} rm -f "${CACHE_DIR}/supported.list" "${CACHE_DIR}/supported_apps.list"
-        fancy_message info "Updating cache of supported apps in the background"
-        list_debs | grep -v -e '^[[:space:]][[:space:]]*\[' | ${ELEVATE} tee "${CACHE_DIR}/supported.list.tmp" >/dev/null
-        ${ELEVATE} mv "${CACHE_DIR}/supported.list.tmp" "${CACHE_DIR}/supported.list"
-        # # belt and braces no longer needed
-        #${ELEVATE} sed -i '/[+]/d' ${CACHE_DIR}/supported.list.tmp
-        cut -d" " -f 1 "${CACHE_DIR}/supported.list" | sort -u | ${ELEVATE} tee "${CACHE_DIR}/supported_apps.list" >/dev/null
+        pgrep -f "$DEBGET_BIN update"
+        if [ $? ]; then
+            # pgrep returned 1 (command not found), delete lockfile and continue
+            fancy_message warn "Lock file found, but job is not running. Deleting $lockfile, cache update continues."
+            ${ELEVATE} rm $lockfile
+        else
+            # pgrep returned 0 (command found), do nothing and return
+            fancy_message warn "Cannot update cache of supported apps: $lockfile found (job still running?)"
+            return 0
+        fi
     fi
+
+    trap "trap - EXIT; ${ELEVATE} rm -f \"$lockfile\"" EXIT
+    ${ELEVATE} touch "$lockfile"
+    ${ELEVATE} rm -f "${CACHE_DIR}/supported.list" "${CACHE_DIR}/supported_apps.list"
+    fancy_message info "Updating cache of supported apps in the background"
+    list_debs | grep -v -e '^[[:space:]][[:space:]]*\[' | ${ELEVATE} tee "${CACHE_DIR}/supported.list.tmp" >/dev/null
+    ${ELEVATE} mv "${CACHE_DIR}/supported.list.tmp" "${CACHE_DIR}/supported.list"
+    # # belt and braces no longer needed
+    #${ELEVATE} sed -i '/[+]/d' ${CACHE_DIR}/supported.list.tmp
+    cut -d" " -f 1 "${CACHE_DIR}/supported.list" | sort -u | ${ELEVATE} tee "${CACHE_DIR}/supported_apps.list" >/dev/null
 }
 
 function update_repos() {
@@ -1543,6 +1551,8 @@ readonly MAIN_REPO_URL="https://raw.githubusercontent.com/wimpysworld/deb-get/ma
 
 readonly USER_AGENT="Mozilla/5.0 (X11; Linux ${HOST_CPU}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36"
 readonly USER_HOME="${HOME}"
+
+readonly DEBGET_BIN=$(basename $0)
 
 parse_machine
 


### PR DESCRIPTION
Hi,
When `deb-get update` gets terminated the `trap` doesn't remove the lockfile. I am using `pgrep` to check if `update` is actually running or not. If not running, delete lockfile and continue the update, if running, then do nothing and return.  
I have another version that doesn't use `lockfile` at all, just `pgrep`, let me know which one do you prefer.  
Thanks,  
Bruno