### PR TITLE
Remove-teams-repo

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -252,7 +252,7 @@ system-monitoring-center
 tabby-terminal
 tailscale
 tarsnap
-teams
+#teams
 teams-for-linux
 teamviewer
 teip


### PR DESCRIPTION
the teams repo is now empty at packages.microsoft.com