### PR TITLE
openrgb: Fix URLs

### DIFF
--- a/01-main/packages/openrgb
+++ b/01-main/packages/openrgb
@@ -3,20 +3,32 @@ ARCHS_SUPPORTED="amd64 armhf"
 CODENAMES_SUPPORTED="buster bullseye bookworm focal jammy noble"
 get_website "https://openrgb.org/releases.html"
 if [ "${ACTION}" != "prettylist" ]; then
+    local codename, regex, deb
     case "${UPSTREAM_CODENAME}" in
         buster)
-            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_buster_[[:xdigit:]]+\.deb" "${CACHE_FILE}" )"
+            codename=buster
         ;;
-        bullseye|focal|jammy)
-            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_bullseye_[[:xdigit:]]+\.deb" "${CACHE_FILE}" )"
-        ;;        
+        bullseye|focal)
+            codename=bullseye
+        ;;
         *)
-            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_bookworm_[[:xdigit:]]+\.deb" "${CACHE_FILE}" )"
+            codename=bookworm
         ;;
     esac
-    VERSION_PUBLISHED="$(echo "${URL}" | grep -o -E '[[:digit:]]+\.[[:digit:]]+'|sort -u)"
+    # allow more complex version numbers, such as 0.9.1, 0.9b, or 0.9-1:
+    regex="/releases/release_[^/]+/openrgb_[^_]+_${HOST_ARCH}_${codename}_[^.]+\.deb"
+    # can return multiple lines:
+    deb=$( grep -m 1 -o -E "${regex}" "${CACHE_FILE}" )
+    # strip everything after the first newline:
+    deb="${deb/$'\n'*/}"
+    URL="https://openrgb.org/${deb}"
+    # grab the first version found in the path (in the directory name):
+    VERSION_PUBLISHED=$( grep -m 1 -o -E '_[^/]+/' <<<"${deb}" )
+    # strip the leading _:
+    VERSION_PUBLISHED="${VERSION_PUBLISHED/_/}"
+    # strip the trailing /:
+    VERSION_PUBLISHED="${VERSION_PUBLISHED/\//}"
 fi
 PRETTY_NAME="OpenRGB"
 WEBSITE="https://openrgb.org/"
 SUMMARY="Open source RGB lighting control that doesn't depend on manufacturer software."
-

--- a/01-main/packages/openrgb
+++ b/01-main/packages/openrgb
@@ -5,13 +5,13 @@ get_website "https://openrgb.org/releases.html"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${UPSTREAM_CODENAME}" in
         buster)
-            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_buster_[[:digit:]]+\.deb" "${CACHE_FILE}" )"
+            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_buster_[[:xdigit:]]+\.deb" "${CACHE_FILE}" )"
         ;;
         bullseye|focal|jammy)
-            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_bullseye_[[:digit:]]+\.deb" "${CACHE_FILE}" )"
+            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_bullseye_[[:xdigit:]]+\.deb" "${CACHE_FILE}" )"
         ;;        
         *)
-            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_bookworm_[[:digit:]]+\.deb" "${CACHE_FILE}" )"
+            URL="https://openrgb.org/$( grep -o -E "/releases/release_[[:digit:]]+\.[[:digit:]]+/openrgb_[[:digit:]]+\.[[:digit:]]_${HOST_ARCH}_bookworm_[[:xdigit:]]+\.deb" "${CACHE_FILE}" )"
         ;;
     esac
     VERSION_PUBLISHED="$(echo "${URL}" | grep -o -E '[[:digit:]]+\.[[:digit:]]+'|sort -u)"

--- a/01-main/packages/openrgb
+++ b/01-main/packages/openrgb
@@ -17,7 +17,7 @@ if [ "${ACTION}" != "prettylist" ]; then
     esac
     # allow more complex version numbers, such as 0.9.1, 0.9b, or 0.9-1:
     regex="/releases/release_[^/]+/openrgb_[^_]+_${HOST_ARCH}_${codename}_[^.]+\.deb"
-    # can return multiple lines:
+    # can return multiple lines (since the content has no newlines):
     deb=$( grep -m 1 -o -E "${regex}" "${CACHE_FILE}" )
     # strip everything after the first newline:
     deb="${deb/$'\n'*/}"


### PR DESCRIPTION
The first URL at
https://openrgb.org/releases.html
is
https://openrgb.org/releases/release_0.9/openrgb_0.9_amd64_buster_b5f46e3.deb 
hence we need xdigit, not digit.

**Edit**:
closes #1047
fixes #1046