### PR TITLE
fix: wraith-master disabled (for now) as repo moved to gitlab

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -299,7 +299,7 @@ winehq-devel
 winehq-stable
 winehq-staging
 wire-desktop
-wraith-master
+# wraith-master
 xemu
 youtube-music
 yq


### PR DESCRIPTION
As https://github.com/serebit/wraith-master is 404, as it's been moved to gitlab.