### PR TITLE
Added package files for Novelwriter and Manuskript

### DIFF
--- a/01-main/packages/manuskript
+++ b/01-main/packages/manuskript
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "olivierkes/manuskript"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
+fi
+PRETTY_NAME="manuskript"
+WEBSITE="http://www.theologeek.ch/manuskript"
+SUMMARY="A open-source tool for writers"

--- a/01-main/packages/novelwriter
+++ b/01-main/packages/novelwriter
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "vkbo/novelWriter"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
+fi
+PRETTY_NAME="novelwriter"
+WEBSITE="https://novelwriter.io"
+SUMMARY="A markdown editor for novels"


### PR DESCRIPTION
Preliminary deb-get support for Novelwriter and Manuskript, two tools published on github that allow novelists to plan and execute their writing.

~~Addresses issues #1056 and #666 if approved~~
Closes #1056
Closes #666 

(This is my first time contributing on this project, and feedback is welcome)