### PR TITLE
fix: bitwig-studio has in-housed downloads

### DIFF
--- a/01-main/packages/bitwig-studio
+++ b/01-main/packages/bitwig-studio
@@ -1,8 +1,9 @@
 DEFVER=1
 get_website "https://www.bitwig.com/download/"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -o "https://www\.bitwig\.com/dl/Bitwig%20Studio/[[:digit:]]*.[[:digit:]]*.[[:digit:]]*/installer_linux" "${CACHE_FILE}")
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d "/" -f 6)"
+    URL="$(follow_url "$(grep -o "https://www\.bitwig\.com/dl/Bitwig%20Studio/[[:digit:]]*.[[:digit:]]*.[[:digit:]]*/installer_linux/" "${CACHE_FILE}")")"
+    VERSION_PUBLISHED="$(echo "\"${URL}\"" | cut -d "/" -f 4)"
+    FILE="${DOWNLOAD_DIR}/Bitwig_Studio_${VERSION_PUBLISHED}.deb"
 fi
 PRETTY_NAME="BitWig Studio"
 WEBSITE="https://www.bitwig.com/"

--- a/01-main/packages/bitwig-studio
+++ b/01-main/packages/bitwig-studio
@@ -1,5 +1,11 @@
 DEFVER=1
 get_website "https://www.bitwig.com/download/"
+# temporarily include a new function here to follow the redirect
+# even on current deb-get versions
+function follow_url() {
+    local TRIM_URL="$(curl -w "%{url_effective}" -I -L -s -S "${1}" -o /dev/null)"
+    printf '%s' "${TRIM_URL}"
+}
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(follow_url "$(grep -o "https://www\.bitwig\.com/dl/Bitwig%20Studio/[[:digit:]]*.[[:digit:]]*.[[:digit:]]*/installer_linux/" "${CACHE_FILE}")")"
     VERSION_PUBLISHED="$(echo "\"${URL}\"" | cut -d "/" -f 4)"

--- a/01-main/packages/bitwig-studio
+++ b/01-main/packages/bitwig-studio
@@ -1,8 +1,8 @@
 DEFVER=1
 get_website "https://www.bitwig.com/download/"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(unroll_url "$(grep -o "https://www\.bitwig\.com/dl/?id=[^&]*&amp;os=installer_linux" "${CACHE_FILE}")")"
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d "/" -f 4)"
+    URL=$(grep -o "https://www\.bitwig\.com/dl/Bitwig%20Studio/[[:digit:]]*.[[:digit:]]*.[[:digit:]]*/installer_linux" "${CACHE_FILE}")
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d "/" -f 6)"
 fi
 PRETTY_NAME="BitWig Studio"
 WEBSITE="https://www.bitwig.com/"

--- a/deb-get
+++ b/deb-get
@@ -148,6 +148,11 @@ function unroll_url() {
     printf '%s' "${TRIM_URL/\.deb*/.deb}"
 }
 
+function follow_url() {
+    local TRIM_URL="$(curl -w "%{url_effective}" -I -L -s -S "${1}" -o /dev/null)"
+    printf '%s' "${TRIM_URL}"
+}
+
 
 function get_github_releases() {
     METHOD="github"


### PR DESCRIPTION
closes #1078 