### PR TITLE
fix: bluejeans has been sunsetted by Verizon

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -22,7 +22,7 @@ bitwarden
 bitwig-studio
 blanket
 blockbench
-bluejeans-v2
+#bluejeans-v2
 bottom
 brave-browser
 brisqi


### PR DESCRIPTION
This needs to be deprecated: they've sunsetted it and replaced the website with a message.