### PR TITLE
fix: update doublecmd repos with correct debian support

### DIFF
--- a/01-main/packages/doublecmd-gtk
+++ b/01-main/packages/doublecmd-gtk
@@ -1,8 +1,15 @@
-DEFVER=1
-CODENAMES_SUPPORTED="buster bullseye focal jammy kinetic lunar mantic noble"
-ASC_KEY_URL="https://download.opensuse.org/repositories/home:Alexx2000/xUbuntu_${UPSTREAM_RELEASE}/Release.key"
+DEFVER=2
+CODENAMES_SUPPORTED="buster bullseye bookworm focal jammy kinetic lunar mantic noble"
+LOCALID=""
+case ${UPSTREAM_ID} in
+    ubuntu)
+        LOCALID="x${UPSTREAM_ID^}" ;; 
+    debian)
+        LOCALID="${UPSTREAM_ID^}" ;; 
+esac
+ASC_KEY_URL="https://download.opensuse.org/repositories/home:Alexx2000/${LOCALID}_${UPSTREAM_RELEASE}/Release.key"
 APT_LIST_NAME="doublecmd"
-APT_REPO_URL="https://download.opensuse.org/repositories/home:/Alexx2000/xUbuntu_${UPSTREAM_RELEASE}/ /"
+APT_REPO_URL="https://download.opensuse.org/repositories/home:/Alexx2000/${LOCALID}_${UPSTREAM_RELEASE}/ /"
 PRETTY_NAME="doublecmd-gtk"
 WEBSITE="https://doublecmd.sourceforge.io/"
 SUMMARY="Doublecmd is a cross-platform open source file manager with two panels side by side. It is inspired by Total Commander and features new ideas."

--- a/01-main/packages/doublecmd-qt
+++ b/01-main/packages/doublecmd-qt
@@ -1,8 +1,15 @@
-DEFVER=1
-CODENAMES_SUPPORTED="buster bullseye focal jammy kinetic lunar mantic noble"
-ASC_KEY_URL="https://download.opensuse.org/repositories/home:Alexx2000/xUbuntu_${UPSTREAM_RELEASE}/Release.key"
+DEFVER=2
+CODENAMES_SUPPORTED="buster bullseye bookworm focal jammy kinetic lunar mantic noble"
+LOCALID=""
+case ${UPSTREAM_ID} in
+    ubuntu)
+        LOCALID="x${UPSTREAM_ID^}" ;; 
+    debian)
+        LOCALID="${UPSTREAM_ID^}" ;; 
+esac
+ASC_KEY_URL="https://download.opensuse.org/repositories/home:Alexx2000/${LOCALID}_${UPSTREAM_RELEASE}/Release.key"
 APT_LIST_NAME="doublecmd"
-APT_REPO_URL="https://download.opensuse.org/repositories/home:/Alexx2000/xUbuntu_${UPSTREAM_RELEASE}/ /"
+APT_REPO_URL="https://download.opensuse.org/repositories/home:/Alexx2000/${LOCALID}_${UPSTREAM_RELEASE}/ /"
 PRETTY_NAME="doublecmd-qt"
 WEBSITE="https://doublecmd.sourceforge.io/"
 SUMMARY="Doublecmd is a cross-platform open source file manager with two panels side by side. It is inspired by Total Commander and features new ideas."


### PR DESCRIPTION
closes #1091 

Both -qt and -gtk variants now have available separate debian as well as ubuntu repos, and bookworm is supported.