### PR TITLE
fix: brave signing key relocated

### DIFF
--- a/01-main/packages/brave-browser
+++ b/01-main/packages/brave-browser
@@ -1,5 +1,5 @@
 DEFVER=1
-ASC_KEY_URL="https://brave-browser-apt-release.s3.brave.com/brave-core.asc"
+GPG_KEY_URL="https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg"
 APT_LIST_NAME="brave-browser-release"
 APT_REPO_URL="https://brave-browser-apt-release.s3.brave.com/ stable main"
 APT_REPO_OPTIONS="arch=amd64"


### PR DESCRIPTION
fixes #1097 
