### PR TITLE
fix: correct obsidian version determination

### DIFF
--- a/01-main/packages/obsidian
+++ b/01-main/packages/obsidian
@@ -2,7 +2,7 @@ DEFVER=1
 get_github_releases "obsidianmd/obsidian-releases"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
 fi
 PRETTY_NAME="Obsidian"
 WEBSITE="https://obsidian.md/"


### PR DESCRIPTION
Obsidian have adopted the most common version tagging scheme
closes #1112 