### PR TITLE
fix: get latest tagged micro release not the nightly

### DIFF
--- a/01-main/packages/micro
+++ b/01-main/packages/micro
@@ -1,7 +1,7 @@
 DEFVER=1
-get_github_releases "zyedidia/micro"
+get_github_releases "zyedidia/micro"  latest
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -v nightly | head -n1 | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
 fi
 PRETTY_NAME="micro"


### PR DESCRIPTION
closes #1126

left in belt-and-braces filter of nightly, but they appear to be tagging releases conventionally so "latest" should suffice