### PR TITLE
feat: move veracrypt to deb over ppa

### DIFF
--- a/01-main/packages/veracrypt
+++ b/01-main/packages/veracrypt
@@ -1,5 +1,14 @@
-DEFVER=1
-PPA="ppa:unit193/encryption"
+DEFVER=2
+ARCHS_SUPPORTED="amd64 arm64"
+CODENAMES_SUPPORTED="buster bullseye focal jammy"
+if [ "${ARCH}" == "amd64" ]; then
+    CODENAMES_SUPPORTED="${CODENAMES_SUPPORTED} noble bookworm"
+fi 
+get_website "https://www.veracrypt.fr/en/Downloads.html"
+if [ "${ACTION}" != "prettylist" ]; then
+    VERSION_PUBLISHED="$(grep 'Latest Stable Release' $CACHE_FILE  |cut -d\  -f 5)"  
+    URL=$(unroll_url "https://launchpad.net/veracrypt/trunk/${VERSION_PUBLISHED}/+download/veracrypt-${VERSION_PUBLISHED}-${UPSTREAM_ID^}-${UPSTREAM_RELEASE}-${HOST_ARCH}.deb\"")
+fi
 PRETTY_NAME="Veracrypt"
 WEBSITE="https://www.veracrypt.fr/en/Downloads.html"
 SUMMARY="VeraCrypt is a free and open-source utility for on-the-fly encryption (OTFE)."


### PR DESCRIPTION
Allow installation on Debian and debian-derived OS

closes #1095 