### PR TITLE
feat: add veracrypt-console

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -281,6 +281,7 @@ urserver
 usbimager
 vagrant
 veracrypt
+veracrypt-console
 virtualbox-6.1
 virtualbox-7.0
 vivaldi-stable

--- a/01-main/packages/veracrypt-console
+++ b/01-main/packages/veracrypt-console
@@ -1,0 +1,14 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+CODENAMES_SUPPORTED="buster bullseye focal jammy"
+if [ "${ARCH}" == "amd64" ]; then
+    CODENAMES_SUPPORTED="${CODENAMES_SUPPORTED} noble bookworm"
+fi 
+get_website "https://www.veracrypt.fr/en/Downloads.html"
+if [ "${ACTION}" != "prettylist" ]; then
+    VERSION_PUBLISHED="$(grep 'Latest Stable Release' $CACHE_FILE  |cut -d\  -f 5)"  
+    URL=$(unroll_url "https://launchpad.net/veracrypt/trunk/${VERSION_PUBLISHED}/+download/veracrypt-console-${VERSION_PUBLISHED}-${UPSTREAM_ID^}-${UPSTREAM_RELEASE}-${HOST_ARCH}.deb\"")
+fi
+PRETTY_NAME="Veracrypt Console"
+WEBSITE="https://www.veracrypt.fr/en/Downloads.html"
+SUMMARY="VeraCrypt is a free and open-source utility for on-the-fly encryption (OTFE)."


### PR DESCRIPTION
Alternative console application for veracrypt for those not wanting the GUI.
Now we are not using the PPA (if #1132 is merged in response to #1095 ) both options should probably be supported as individual debs.