### PR TITLE
fix: fastfetch to use HOST_ARCH

### DIFF
--- a/01-main/packages/fastfetch
+++ b/01-main/packages/fastfetch
@@ -9,7 +9,7 @@ case $(UPSTREAM_CODENAME) in
         ;;
     *)
         URL=$(grep "browser_download_url.*linux-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
-        ARCHS_SUPPORTED="amd64 arm64"
+        ARCHS_SUPPORTED="amd64 arm64 riscv64"
         ;;
 esac
 

--- a/01-main/packages/fastfetch
+++ b/01-main/packages/fastfetch
@@ -8,7 +8,7 @@ case $(UPSTREAM_CODENAME) in
         ARCHS_SUPPORTED="amd64"
         ;;
     *)
-        URL=$(grep "browser_download_url.*linux-${HOST_CPU}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+        URL=$(grep "browser_download_url.*linux-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
         ARCHS_SUPPORTED="amd64 arm64"
         ;;
 esac


### PR DESCRIPTION
fastfetch package release naming was changed.
HOST_CPU resolves to `x86_x64`, but the fastfetch releases now have `amd64` which is HOST_ARCH

fixes #1130 
closes #1131 
