### PR TITLE
fix(quickgui): repoint PPA to current release

### DIFF
--- a/01-main/packages/quickgui
+++ b/01-main/packages/quickgui
@@ -1,5 +1,5 @@
-DEFVER=1
-PPA="ppa:yannick-mauray/quickgui"
+DEFVER=2
+PPA="ppa:flexiondotorg/quickemu"
 PRETTY_NAME="Quickgui"
 WEBSITE="https://github.com/quickemu-project/quickgui"
 SUMMARY="A Flutter frontend for Quickemu."


### PR DESCRIPTION
Latest release has moved to quickemu PPA
We should actually move to getting the deb directly from github, and PPA users probably already had both PPAs in play and found the new release anyway, but until a repoint to github is ready ... 