### PR TITLE
Fix(quickgui): use GitHub instead of PPA for quickgui

### DIFF
--- a/01-main/packages/quickgui
+++ b/01-main/packages/quickgui
@@ -1,5 +1,10 @@
-DEFVER=1
-PPA="ppa:yannick-mauray/quickgui"
+DEFVER=3
+get_github_releases "quickemu-project/quickgui" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*\-linux.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
+fi
+
 PRETTY_NAME="Quickgui"
 WEBSITE="https://github.com/quickemu-project/quickgui"
 SUMMARY="A Flutter frontend for Quickemu."


### PR DESCRIPTION
Replacement for #1140 . This moves quickgui to use github repository instead of PPA

closes #1140