### PR TITLE
feat: move battery-monitor from PPA to github

### DIFF
--- a/01-main/packages/battery-monitor
+++ b/01-main/packages/battery-monitor
@@ -1,7 +1,10 @@
-DEFVER=1
+DEFVER=2
 CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble"
-APT_LIST_NAME="apps.mamolinux.org"
-PPA="ppa:mamolinux/gui-apps"
+get_github_releases "mamolinux/battery-monitor" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
+fi
 PRETTY_NAME="Battery Monitor"
 WEBSITE="https://hsbasu.github.io/battery-monitor/"
 SUMMARY="An X-platform utility tool developed on Python, notifies about charging, discharging, and critically low battery state of the battery on laptop."


### PR DESCRIPTION
closes #1146 

@hsbasu this would seem to be a good option for deb-get users as it widens availability, but I'll leave it draft for now since you moved it to the PPA in #1022 . If you're releasing on github routinely now as well as launchpad I recommend we go ahead but will leave it draft for a short while in case you have concerns. 