### PR TITLE
Fix(bottom): get standard rather than musl version.

### DIFF
--- a/01-main/packages/bottom
+++ b/01-main/packages/bottom
@@ -1,7 +1,7 @@
 DEFVER=1
 get_github_releases "ClementTsang/bottom" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
+    URL=$(grep "browser_download_url.*bottom_.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
 fi
 PRETTY_NAME="bottom"

--- a/01-main/packages/bottom
+++ b/01-main/packages/bottom
@@ -1,4 +1,5 @@
 DEFVER=1
+ARCHS_SUPPORTED="amd64 armhf arm64"
 get_github_releases "ClementTsang/bottom" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*bottom_.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)


### PR DESCRIPTION
closes #1153 
Also adds arm support.

Users who prefer the bottom-musl package could override with something like:

``` shell
sed 's/bottom_/bottom-musl_/' 01-main/packages/bottom >/etc/deb-get/99-local.d/bottom
```