### PR TITLE
fix: get latest released deb for micro

### DIFF
--- a/01-main/packages/micro
+++ b/01-main/packages/micro
@@ -1,7 +1,7 @@
 DEFVER=1
-get_github_releases "zyedidia/micro"  latest
+get_github_releases "zyedidia/micro"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -v nightly | head -n1 | cut -d'"' -f4)
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v nightly | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
 fi
 PRETTY_NAME="micro"


### PR DESCRIPTION
micro are preparing another release but seem to have stopped building a deb while preparing.

This will work around the resultant error by getting all releases and will pick up any future deb.
If they don't continue packaging debs we'll need to deprecate.

