### PR TITLE
fix: correctly support bookworm and noble for veracrypt

### DIFF
--- a/01-main/packages/veracrypt
+++ b/01-main/packages/veracrypt
@@ -1,9 +1,10 @@
 DEFVER=2
-ARCHS_SUPPORTED="amd64 arm64"
-CODENAMES_SUPPORTED="buster bullseye focal jammy"
-if [ "${ARCH}" == "amd64" ]; then
-    CODENAMES_SUPPORTED="${CODENAMES_SUPPORTED} noble bookworm"
-fi 
+ARCHS_SUPPORTED="amd64 arm64 armhf"
+case ${HOST_ARCH} in
+    amd64) CODENAMES_SUPPORTED="bullseye bookworm focal jammy noble" ;;
+    arm64) CODENAMES_SUPPORTED="bullseye bookworm focal jammy noble" ;;
+    armhf) CODENAMES_SUPPORTED="bullseye bookworm focal" ;;
+esac
 get_website "https://www.veracrypt.fr/en/Downloads.html"
 if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED="$(grep 'Latest Stable Release' $CACHE_FILE  |cut -d\  -f 5)"  

--- a/01-main/packages/veracrypt
+++ b/01-main/packages/veracrypt
@@ -7,7 +7,8 @@ case ${HOST_ARCH} in
 esac
 get_website "https://www.veracrypt.fr/en/Downloads.html"
 if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED="$(grep 'Latest Stable Release' $CACHE_FILE  |cut -d\  -f 5)"  
+    VERSION_PUBLISHED=$(grep -Eo '/Linux: Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ' /var/cache/deb-get/veracrypt.html | cut -d\  -f3)
+
     URL=$(unroll_url "https://launchpad.net/veracrypt/trunk/${VERSION_PUBLISHED}/+download/veracrypt-${VERSION_PUBLISHED}-${UPSTREAM_ID^}-${UPSTREAM_RELEASE}-${HOST_ARCH}.deb\"")
 fi
 PRETTY_NAME="Veracrypt"

--- a/01-main/packages/veracrypt-console
+++ b/01-main/packages/veracrypt-console
@@ -1,9 +1,10 @@
 DEFVER=1
-ARCHS_SUPPORTED="amd64 arm64"
-CODENAMES_SUPPORTED="buster bullseye focal jammy"
-if [ "${ARCH}" == "amd64" ]; then
-    CODENAMES_SUPPORTED="${CODENAMES_SUPPORTED} noble bookworm"
-fi 
+ARCHS_SUPPORTED="amd64 arm64 armhf"
+case ${HOST_ARCH} in
+    amd64) CODENAMES_SUPPORTED="bullseye bookworm focal jammy noble" ;;
+    arm64) CODENAMES_SUPPORTED="bullseye bookworm focal jammy noble" ;;
+    armhf) CODENAMES_SUPPORTED="bullseye bookworm focal" ;;
+esac 
 get_website "https://www.veracrypt.fr/en/Downloads.html"
 if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED="$(grep 'Latest Stable Release' $CACHE_FILE  |cut -d\  -f 5)"  

--- a/01-main/packages/veracrypt-console
+++ b/01-main/packages/veracrypt-console
@@ -7,7 +7,8 @@ case ${HOST_ARCH} in
 esac 
 get_website "https://www.veracrypt.fr/en/Downloads.html"
 if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED="$(grep 'Latest Stable Release' $CACHE_FILE  |cut -d\  -f 5)"  
+      VERSION_PUBLISHED=$(grep -Eo '/Linux: Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ' /var/cache/deb-get/veracrypt.html | cut -d\  -f3)
+
     URL=$(unroll_url "https://launchpad.net/veracrypt/trunk/${VERSION_PUBLISHED}/+download/veracrypt-console-${VERSION_PUBLISHED}-${UPSTREAM_ID^}-${UPSTREAM_RELEASE}-${HOST_ARCH}.deb\"")
 fi
 PRETTY_NAME="Veracrypt Console"


### PR DESCRIPTION
closes #1161 
closes #1164 

Aligns architecture and release support with https://www.veracrypt.fr/en/Downloads.html