### PR TITLE
fix: reflect changed release naming of whalebird

### DIFF
--- a/01-main/packages/whalebird
+++ b/01-main/packages/whalebird
@@ -1,8 +1,8 @@
 DEFVER=1
 get_github_releases "h3poteto/whalebird-desktop"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(grep "browser_download_url.*x64\.deb\"" "${CACHE_FILE}" | grep -v beta | head -n1 | cut -d'"' -f4)"
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
+    URL="$(grep "browser_download_url.*64\.deb\"" "${CACHE_FILE}" | grep -v -e beta -e alpha -e '-rc\.' | head -n1 | cut -d'"' -f4)"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
 fi
 PRETTY_NAME="Whalebird"
 WEBSITE="https://whalebird.social/"


### PR DESCRIPTION
Whalebird naming has changed, this will catch the new naming as well as the old in case it ever changes back.