### PR TITLE
fix: deprecate nala

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -162,8 +162,8 @@ mqttx
 ms-365-electron
 mullvad-vpn
 multimc
-nala
-nala-legacy
+#nala
+#nala-legacy
 nekoray
 nemo-mediainfo-tab
 neo4j


### PR DESCRIPTION
Users should install Nala from their distribution or using the upstream script provided to allow the developers to manage apt preferences protections.
See https://github.com/wimpysworld/deb-get/issues/1098#issuecomment-2179074838

https://gitlab.com/volian/nala/-/wikis/Installation

```shell
curl https://gitlab.com/volian/volian-archive/-/raw/main/install-nala.sh | bash
```

