### PR TITLE
fix: extend deltachat-desktop ARCH support to arm64 and filter

### DIFF
--- a/01-main/packages/deltachat-desktop
+++ b/01-main/packages/deltachat-desktop
@@ -1,7 +1,8 @@
 DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
 get_website "$(unroll_url https://delta.chat/download)"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="$(grep "\.deb\"" "${CACHE_FILE}" | cut -d "\"" -f 2)"
+    URL="$(grep "${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d "\"" -f 2)"
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d "/" -f 5 | tr -d v)"
 fi
 PRETTY_NAME="Delta Chat"


### PR DESCRIPTION
Closes #1168 