### PR TITLE
fix: add  support for oracular to package defs

### DIFF
--- a/01-main/packages/battery-monitor
+++ b/01-main/packages/battery-monitor
@@ -1,5 +1,5 @@
 DEFVER=2
-CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble oracular"
 get_github_releases "mamolinux/battery-monitor" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)

--- a/01-main/packages/firefox
+++ b/01-main/packages/firefox
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="ppa.mozilla.org"
 PPA="ppa:mozillateam/ppa"
 PRETTY_NAME="Firefox"

--- a/01-main/packages/firefox-beta
+++ b/01-main/packages/firefox-beta
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Beta"

--- a/01-main/packages/firefox-devedition
+++ b/01-main/packages/firefox-devedition
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Developer Edition"

--- a/01-main/packages/firefox-esr
+++ b/01-main/packages/firefox-esr
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="ppa.mozilla.org"
 PPA="ppa:mozillateam/ppa"
 PRETTY_NAME="Firefox ESR"

--- a/01-main/packages/firefox-nightly
+++ b/01-main/packages/firefox-nightly
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Nightly"

--- a/01-main/packages/flameshot
+++ b/01-main/packages/flameshot
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="buster bullseye focal jammy mantic noble"
+CODENAMES_SUPPORTED="buster bullseye focal jammy mantic noble oracular"
 get_github_releases "flameshot-org/flameshot" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${UPSTREAM_RELEASE}" in

--- a/01-main/packages/i3
+++ b/01-main/packages/i3
@@ -1,7 +1,7 @@
 DEFVER=2
 # Debian should not use this repo
 # See https://i3wm.org/docs/repositories.html
-CODENAMES_SUPPORTED="bionic focal jammy lunar mantic noble"
+CODENAMES_SUPPORTED="bionic focal jammy lunar mantic noble oracular"
 GPG_KEY_ID="E3CA1A89941C42E6"
 APT_REPO_URL="http://debian.sur5r.net/i3/ ${UPSTREAM_CODENAME} universe"
 APT_REPO_OPTIONS="arch=amd64"

--- a/01-main/packages/media-downloader
+++ b/01-main/packages/media-downloader
@@ -4,7 +4,7 @@ case ${UPSTREAM_ID} in
     ubuntu) IS_UBUNTU="x";;
     *) IS_UBUNTU="";;
 esac
-CODENAMES_SUPPORTED="stretch buster bullseye bookworm sid bionic focal jammy lunar mantic noble"
+CODENAMES_SUPPORTED="stretch buster bullseye bookworm sid bionic focal jammy lunar mantic noble oracular"
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/Release.key"
 APT_REPO_URL="http://download.opensuse.org/repositories/home:/obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/ /"
 PRETTY_NAME="Media Downloader"

--- a/01-main/packages/nala
+++ b/01-main/packages/nala
@@ -1,6 +1,6 @@
 DEFVER=2
 ARCHS_SUPPORTED="amd64 arm64 armhf"
-CODENAMES_SUPPORTED="bookworm sid jammy lunar mantic noble"
+CODENAMES_SUPPORTED="bookworm sid jammy lunar mantic noble oracular"
 GPG_KEY_URL="https://gitlab.com/volian/volian-archive/-/raw/main/volian-archive-scar-unstable.gpg?ref_type=heads&inline=false"
 APT_REPO_URL="http://deb.volian.org/volian/ nala main"
 APT_REPO_OPTIONS="arch=${HOST_ARCH}"

--- a/01-main/packages/oculante
+++ b/01-main/packages/oculante
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble oracular"
 get_github_releases "woelper/oculante" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)

--- a/01-main/packages/onedriver
+++ b/01-main/packages/onedriver
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-CODENAMES_SUPPORTED="buster bullseye bookworm sid focal jammy lunar mantic noble"
+CODENAMES_SUPPORTED="bullseye bookworm sid focal jammy mantic"
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:jstaf/$(sed 's/d/D/;s/ub/xUb/' <<< "$UPSTREAM_ID")_$(sed 's/12/Testing/;s/u/U/' <<< "$UPSTREAM_RELEASE")/Release.key"
 APT_REPO_URL="http://download.opensuse.org/repositories/home:/jstaf/$(sed 's/d/D/;s/ub/xUb/' <<< "$UPSTREAM_ID")_$(sed 's/12/Testing/;s/u/U/' <<< "$UPSTREAM_RELEASE")/ /"
 APT_REPO_OPTIONS="arch=${HOST_ARCH}"

--- a/01-main/packages/pet
+++ b/01-main/packages/pet
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armv6 i386"
-CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble oracular"
 get_github_releases "knqyf263/pet" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)

--- a/01-main/packages/waydroid
+++ b/01-main/packages/waydroid
@@ -1,5 +1,5 @@
 DEFVER=2
-CODENAMES_SUPPORTED="bullseye bookworm trixie sid focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="bullseye bookworm trixie sid focal jammy kinetic lunar mantic noble oracular"
 GPG_KEY_URL="https://repo.waydro.id/waydroid.gpg"
 
 


### PR DESCRIPTION
The following apps have explicit support for oracular.  

 - [x] battery-monitor
 - [x] firefox
 - [x] firefox-beta
 - [x] firefox-devedition
 - [x] firefox-esr
 - [x] firefox-nightly
 - [x] flameshot 
 - [x] i3
 - [x] nala
 - [x] oculante
 - [x] pet
 - [x] waydroid
