### PR TITLE
fix: align beersmith definition to revised website

### DIFF
--- a/01-main/packages/battery-monitor
+++ b/01-main/packages/battery-monitor
@@ -1,5 +1,5 @@
 DEFVER=2
-CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble oracular"
 get_github_releases "mamolinux/battery-monitor" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)

--- a/01-main/packages/beersmith3
+++ b/01-main/packages/beersmith3
@@ -1,19 +1,22 @@
 DEFVER=1
-CODENAMES_SUPPORTED="bionic focal jammy mantic noble"
+CODENAMES_SUPPORTED="bionic focal jammy mantic noble oracular"
 get_website "https://beersmith.com/download-beersmith/"
 if [ "${ACTION}" != "prettylist" ]; then
     case ${UPSTREAM_CODENAME} in
         bionic)
-            URL="$(grep "18\.04_amd64\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f2)"
+            URL="https://beersmith3-1.s3.amazonaws.com/BeerSmith-3.1.8_18.04_amd64.deb"
         ;;
         focal)
-            URL="$( grep "3\.2\.7_amd64\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f2)"
+	        URL="https://beersmith3-2.s3.amazonaws.com/BeerSmith-3.2.7_amd64.deb"
         ;;
         jammy|mantic)
-            URL="$(grep "amd64\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f2)"
+	        URL="https://beersmith3-2.s3.amazonaws.com/BeerSmith-3.2.8_amd64.deb"
         ;;
+	    noble|oracular)
+	        URL="https://beersmith3-2.s3.amazonaws.com/BeerSmith-3.2.8_24_04_amd64.deb"
+	    ;;    
         *)
-            URL="$(grep "amd64\.deb\"" "${CACHE_FILE}"| head -n1 | cut -d'"' -f2)"
+	        URL="https://beersmith3-2.s3.amazonaws.com/BeerSmith-3.2.8_24_04_amd64.deb"
         ;;
     esac
 

--- a/01-main/packages/beersmith3
+++ b/01-main/packages/beersmith3
@@ -2,21 +2,22 @@ DEFVER=1
 CODENAMES_SUPPORTED="bionic focal jammy mantic noble oracular"
 get_website "https://beersmith.com/download-beersmith/"
 if [ "${ACTION}" != "prettylist" ]; then
+    DL=$(grep -o -E '\"https://beer.*\.deb\"' "$CACHE_FILE" | sed 's/<br>/\n/g')
     case ${UPSTREAM_CODENAME} in
         bionic)
             URL="https://beersmith3-1.s3.amazonaws.com/BeerSmith-3.1.8_18.04_amd64.deb"
         ;;
         focal)
-	        URL="https://beersmith3-2.s3.amazonaws.com/BeerSmith-3.2.7_amd64.deb"
+            URL=$(grep 20.04 <<<"${DL}" | cut -d\" -f4)
         ;;
         jammy|mantic)
-	        URL="https://beersmith3-2.s3.amazonaws.com/BeerSmith-3.2.8_amd64.deb"
+            URL=$(grep 22.04 <<<"${DL}" | cut -d\" -f4)
         ;;
-	    noble|oracular)
-	        URL="https://beersmith3-2.s3.amazonaws.com/BeerSmith-3.2.8_24_04_amd64.deb"
+        noble|oracular)
+            URL=$(grep 24.04 <<<"${DL}" | cut -d\" -f2 | uniq)
 	    ;;    
         *)
-	        URL="https://beersmith3-2.s3.amazonaws.com/BeerSmith-3.2.8_24_04_amd64.deb"
+            URL=$(grep "${UPSTREAM_RELEASE}" <<<"${DL}" | cut -d\" -f4)
         ;;
     esac
 

--- a/01-main/packages/deltachat-desktop
+++ b/01-main/packages/deltachat-desktop
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-get_website "$(unroll_url https://delta.chat/download)"
+get_website "$(unroll_url https://delta.chat/en/download)"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep "${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d "\"" -f 2)"
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d "/" -f 5 | tr -d v)"

--- a/01-main/packages/doublecmd-gtk
+++ b/01-main/packages/doublecmd-gtk
@@ -1,5 +1,5 @@
 DEFVER=2
-CODENAMES_SUPPORTED="buster bullseye bookworm focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="buster bullseye bookworm focal jammy kinetic lunar mantic noble oracular"
 LOCALID=""
 case ${UPSTREAM_ID} in
     ubuntu)
@@ -7,6 +7,11 @@ case ${UPSTREAM_ID} in
     debian)
         LOCALID="${UPSTREAM_ID^}" ;; 
 esac
+# Even though
+#   https://software.opensuse.org//download.html?project=home%3AAlexx2000%3Adoublecmd-svn&package=doublecmd-qt
+# shows
+#   http://download.opensuse.org/repositories/home:/Alexx2000:/doublecmd-svn/xUbuntu_24.10/
+# these URLs still work:
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:Alexx2000/${LOCALID}_${UPSTREAM_RELEASE}/Release.key"
 APT_LIST_NAME="doublecmd"
 APT_REPO_URL="https://download.opensuse.org/repositories/home:/Alexx2000/${LOCALID}_${UPSTREAM_RELEASE}/ /"

--- a/01-main/packages/doublecmd-qt
+++ b/01-main/packages/doublecmd-qt
@@ -1,5 +1,5 @@
 DEFVER=2
-CODENAMES_SUPPORTED="buster bullseye bookworm focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="buster bullseye bookworm focal jammy kinetic lunar mantic noble oracular"
 LOCALID=""
 case ${UPSTREAM_ID} in
     ubuntu)
@@ -7,6 +7,11 @@ case ${UPSTREAM_ID} in
     debian)
         LOCALID="${UPSTREAM_ID^}" ;; 
 esac
+# Even though
+#   https://software.opensuse.org//download.html?project=home%3AAlexx2000%3Adoublecmd-svn&package=doublecmd-qt
+# shows
+#   http://download.opensuse.org/repositories/home:/Alexx2000:/doublecmd-svn/xUbuntu_24.10/
+# these URLs still work:
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:Alexx2000/${LOCALID}_${UPSTREAM_RELEASE}/Release.key"
 APT_LIST_NAME="doublecmd"
 APT_REPO_URL="https://download.opensuse.org/repositories/home:/Alexx2000/${LOCALID}_${UPSTREAM_RELEASE}/ /"

--- a/01-main/packages/firefox
+++ b/01-main/packages/firefox
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="ppa.mozilla.org"
 PPA="ppa:mozillateam/ppa"
 PRETTY_NAME="Firefox"

--- a/01-main/packages/firefox-beta
+++ b/01-main/packages/firefox-beta
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Beta"

--- a/01-main/packages/firefox-devedition
+++ b/01-main/packages/firefox-devedition
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Developer Edition"

--- a/01-main/packages/firefox-esr
+++ b/01-main/packages/firefox-esr
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="ppa.mozilla.org"
 PPA="ppa:mozillateam/ppa"
 PRETTY_NAME="Firefox ESR"

--- a/01-main/packages/firefox-nightly
+++ b/01-main/packages/firefox-nightly
@@ -2,8 +2,8 @@ DEFVER=1
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
 ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
 # Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble"
+# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
+CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Nightly"

--- a/01-main/packages/flameshot
+++ b/01-main/packages/flameshot
@@ -2,19 +2,11 @@ DEFVER=1
 CODENAMES_SUPPORTED="buster bullseye focal jammy mantic noble oracular"
 get_github_releases "flameshot-org/flameshot" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    case "${UPSTREAM_RELEASE}" in
-        22.10) ONLY_ONE="tail -1" ;;
-        *) ONLY_ONE="head -1"
-    esac
-    if ! grep -q -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}.*\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json"; then
-      case "${UPSTREAM_RELEASE}" in
-        # For 24.x and 25.x, use 22.04, if a more recent version hasn't been released
-        2[45].*) UPSTREAM_RELEASE=22.04 ;;
-      esac
+    URL="$(grep -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE}.*\.${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+    if [ -z "${URL}" ]; then
+        URL="$(sort -r ${CACHE_FILE} | grep -m 1 -E "browser_download_url.*\.${UPSTREAM_ID}-.*\.${HOST_ARCH}\.deb\"" | cut -d'"' -f4)"
     fi
-    URL="$(grep  -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}.*\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | $ONLY_ONE | cut -d'"' -f4)"
-    local VERSION_TMP="${URL##*/flameshot-}"
-    VERSION_PUBLISHED="${VERSION_TMP%%[-.]${UPSTREAM_ID}*}"
+    VERSION_PUBLISHED=$(cut -d'/' -f8 <<<"${URL}" | tr -d v)
 fi
 PRETTY_NAME="Flameshot"
 WEBSITE="https://flameshot.org/"

--- a/01-main/packages/flameshot
+++ b/01-main/packages/flameshot
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="buster bullseye focal jammy mantic noble"
+CODENAMES_SUPPORTED="buster bullseye focal jammy mantic noble oracular"
 get_github_releases "flameshot-org/flameshot" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${UPSTREAM_RELEASE}" in

--- a/01-main/packages/i3
+++ b/01-main/packages/i3
@@ -1,7 +1,7 @@
 DEFVER=2
 # Debian should not use this repo
 # See https://i3wm.org/docs/repositories.html
-CODENAMES_SUPPORTED="bionic focal jammy lunar mantic noble"
+CODENAMES_SUPPORTED="bionic focal jammy lunar mantic noble oracular"
 GPG_KEY_ID="E3CA1A89941C42E6"
 APT_REPO_URL="http://debian.sur5r.net/i3/ ${UPSTREAM_CODENAME} universe"
 APT_REPO_OPTIONS="arch=amd64"

--- a/01-main/packages/media-downloader
+++ b/01-main/packages/media-downloader
@@ -4,7 +4,7 @@ case ${UPSTREAM_ID} in
     ubuntu) IS_UBUNTU="x";;
     *) IS_UBUNTU="";;
 esac
-CODENAMES_SUPPORTED="stretch buster bullseye bookworm sid bionic focal jammy lunar mantic noble"
+CODENAMES_SUPPORTED="stretch buster bullseye bookworm sid bionic focal jammy lunar mantic noble oracular"
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/Release.key"
 APT_REPO_URL="http://download.opensuse.org/repositories/home:/obs_mhogomchungu/${IS_UBUNTU}${UPSTREAM_ID^}_${UPSTREAM_RELEASE}/ /"
 PRETTY_NAME="Media Downloader"

--- a/01-main/packages/nala
+++ b/01-main/packages/nala
@@ -1,6 +1,6 @@
 DEFVER=2
 ARCHS_SUPPORTED="amd64 arm64 armhf"
-CODENAMES_SUPPORTED="bookworm sid jammy lunar mantic noble"
+CODENAMES_SUPPORTED="bookworm sid jammy lunar mantic noble oracular"
 GPG_KEY_URL="https://gitlab.com/volian/volian-archive/-/raw/main/volian-archive-scar-unstable.gpg?ref_type=heads&inline=false"
 APT_REPO_URL="http://deb.volian.org/volian/ nala main"
 APT_REPO_OPTIONS="arch=${HOST_ARCH}"

--- a/01-main/packages/nuclear
+++ b/01-main/packages/nuclear
@@ -7,5 +7,5 @@ if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | sed "s/v//")"
 fi
 PRETTY_NAME="Nuclear"
-WEBSITE="https://nuclear.js.org/"
+WEBSITE="https://nuclearplayer.com/"
 SUMMARY="Streaming music player that finds free music for you."

--- a/01-main/packages/oculante
+++ b/01-main/packages/oculante
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble oracular"
 get_github_releases "woelper/oculante" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)

--- a/01-main/packages/onedriver
+++ b/01-main/packages/onedriver
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-CODENAMES_SUPPORTED="buster bullseye bookworm sid focal jammy lunar mantic noble"
+CODENAMES_SUPPORTED="bullseye bookworm sid focal jammy mantic"
 ASC_KEY_URL="https://download.opensuse.org/repositories/home:jstaf/$(sed 's/d/D/;s/ub/xUb/' <<< "$UPSTREAM_ID")_$(sed 's/12/Testing/;s/u/U/' <<< "$UPSTREAM_RELEASE")/Release.key"
 APT_REPO_URL="http://download.opensuse.org/repositories/home:/jstaf/$(sed 's/d/D/;s/ub/xUb/' <<< "$UPSTREAM_ID")_$(sed 's/12/Testing/;s/u/U/' <<< "$UPSTREAM_RELEASE")/ /"
 APT_REPO_OPTIONS="arch=${HOST_ARCH}"

--- a/01-main/packages/pet
+++ b/01-main/packages/pet
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armv6 i386"
-CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="bookworm bullseye buster trixie sid focal jammy kinetic lunar mantic noble oracular"
 get_github_releases "knqyf263/pet" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)

--- a/01-main/packages/waydroid
+++ b/01-main/packages/waydroid
@@ -1,5 +1,5 @@
 DEFVER=2
-CODENAMES_SUPPORTED="bullseye bookworm trixie sid focal jammy kinetic lunar mantic noble"
+CODENAMES_SUPPORTED="bullseye bookworm trixie sid focal jammy kinetic lunar mantic noble oracular"
 GPG_KEY_URL="https://repo.waydro.id/waydroid.gpg"
 
 

--- a/deb-get
+++ b/deb-get
@@ -156,7 +156,7 @@ function follow_url() {
 
 function get_github_releases() {
     METHOD="github"
-    CACHE_FILE="${CACHE_DIR}/${APP}.json"
+    CACHE_FILE="${CACHE_DIR}/${APP}.json_extract"
     # Cache github releases json for 1 hour to try and prevent API rate limits
     #   https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
     #   {"message":"API rate limit exceeded for 62.31.16.154. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
@@ -167,8 +167,8 @@ function get_github_releases() {
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             fancy_message info "Updating ${CACHE_FILE}"
             local URL="https://api.github.com/repos/${1}/releases${2:+/$2}"
-            wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps "${URL}" -O "${CACHE_FILE}")
-            ${ELEVATE} "${wgetcmdarray[@]}" || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
+            wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps "${URL}" -O- )
+            ${ELEVATE} "${wgetcmdarray[@]}" | sed '/browser_download/!d;/\.deb/!d' >  "${CACHE_FILE}" || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
             if [ -f "${CACHE_FILE}" ] && grep "API rate limit exceeded" "${CACHE_FILE}"; then
                 fancy_message warn "Updating ${CACHE_FILE} exceeded GitHub API limits. Deleting it."
                 ${ELEVATE} rm "${CACHE_FILE}" 2>/dev/null
@@ -1372,7 +1372,7 @@ function dg_action_cache() {
 function dg_action_clean() {
         elevate_privs
         ${ELEVATE} rm -fv "${CACHE_DIR}"/*.deb
-        ${ELEVATE} rm -fv "${CACHE_DIR}"/*.json
+        ${ELEVATE} rm -fv "${CACHE_DIR}"/*.json*
         ${ELEVATE} rm -fv "${CACHE_DIR}"/*.html
         ${ELEVATE} rm -fv "${CACHE_DIR}"/*.txt
 

--- a/deb-get
+++ b/deb-get
@@ -173,6 +173,8 @@ function get_github_releases() {
                 fancy_message warn "Updating ${CACHE_FILE} exceeded GitHub API limits. Deleting it."
                 ${ELEVATE} rm "${CACHE_FILE}" 2>/dev/null
             fi
+            # we only want the .deb files download urls from the json
+            ${ELEVATE} sed -i '/browser_download/!d;/\.deb/!d' ${CACHE_FILE}
         fi
     fi
 }


### PR DESCRIPTION
They have split legacy versions off to a second page and redesigned the download page so replace dynamic parsing  for now

Fixes #1192 