### PR TITLE
Feat: pre-trim github json cache

### DIFF
--- a/01-main/packages/flameshot
+++ b/01-main/packages/flameshot
@@ -2,19 +2,11 @@ DEFVER=1
 CODENAMES_SUPPORTED="buster bullseye focal jammy mantic noble"
 get_github_releases "flameshot-org/flameshot" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    case "${UPSTREAM_RELEASE}" in
-        22.10) ONLY_ONE="tail -1" ;;
-        *) ONLY_ONE="head -1"
-    esac
-    if ! grep -q -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}.*\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json"; then
-      case "${UPSTREAM_RELEASE}" in
-        # For 24.x and 25.x, use 22.04, if a more recent version hasn't been released
-        2[45].*) UPSTREAM_RELEASE=22.04 ;;
-      esac
+    URL="$(grep -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE}.*\.${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+    if [ -z "${URL}" ]; then
+        URL="$(sort -r ${CACHE_FILE} | grep -m 1 -E "browser_download_url.*\.${UPSTREAM_ID}-.*\.${HOST_ARCH}\.deb\"" | cut -d'"' -f4)"
     fi
-    URL="$(grep  -E "browser_download_url.*\.${UPSTREAM_ID}-${UPSTREAM_RELEASE:0:2}.*\.${HOST_ARCH}\.deb\"" "${CACHE_DIR}/${APP}.json" | $ONLY_ONE | cut -d'"' -f4)"
-    local VERSION_TMP="${URL##*/flameshot-}"
-    VERSION_PUBLISHED="${VERSION_TMP%%[-.]${UPSTREAM_ID}*}"
+    VERSION_PUBLISHED=$(cut -d'/' -f8 <<<"${URL}" | tr -d v)
 fi
 PRETTY_NAME="Flameshot"
 WEBSITE="https://flameshot.org/"

--- a/deb-get
+++ b/deb-get
@@ -156,7 +156,7 @@ function follow_url() {
 
 function get_github_releases() {
     METHOD="github"
-    CACHE_FILE="${CACHE_DIR}/${APP}.json"
+    CACHE_FILE="${CACHE_DIR}/${APP}.json_extract"
     # Cache github releases json for 1 hour to try and prevent API rate limits
     #   https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
     #   {"message":"API rate limit exceeded for 62.31.16.154. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
@@ -167,8 +167,8 @@ function get_github_releases() {
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             fancy_message info "Updating ${CACHE_FILE}"
             local URL="https://api.github.com/repos/${1}/releases${2:+/$2}"
-            wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps "${URL}" -O "${CACHE_FILE}")
-            ${ELEVATE} "${wgetcmdarray[@]}" || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
+            wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps "${URL}" -O- )
+            ${ELEVATE} "${wgetcmdarray[@]}" | sed '/browser_download/!d;/\.deb/!d' >  "${CACHE_FILE}" || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
             if [ -f "${CACHE_FILE}" ] && grep "API rate limit exceeded" "${CACHE_FILE}"; then
                 fancy_message warn "Updating ${CACHE_FILE} exceeded GitHub API limits. Deleting it."
                 ${ELEVATE} rm "${CACHE_FILE}" 2>/dev/null
@@ -1372,7 +1372,7 @@ function dg_action_cache() {
 function dg_action_clean() {
         elevate_privs
         ${ELEVATE} rm -fv "${CACHE_DIR}"/*.deb
-        ${ELEVATE} rm -fv "${CACHE_DIR}"/*.json
+        ${ELEVATE} rm -fv "${CACHE_DIR}"/*.json*
         ${ELEVATE} rm -fv "${CACHE_DIR}"/*.html
         ${ELEVATE} rm -fv "${CACHE_DIR}"/*.txt
 

--- a/deb-get
+++ b/deb-get
@@ -173,6 +173,8 @@ function get_github_releases() {
                 fancy_message warn "Updating ${CACHE_FILE} exceeded GitHub API limits. Deleting it."
                 ${ELEVATE} rm "${CACHE_FILE}" 2>/dev/null
             fi
+            # we only want the .deb files download urls from the json
+            ${ELEVATE} sed -i '/browser_download/!d;/\.deb/!d' ${CACHE_FILE}
         fi
     fi
 }


### PR DESCRIPTION
Avoid storing large amounts of json we never look at again from the github api.
For repos where we cannot rely on just fetching the latest we can get substantial amounts of data we don't want to see and would be better not writing out to the cache and then filtering out every time we look at the cache.