### PR TITLE
feat: add TriliumNext via optional extra successor repo

### DIFF
--- a/11-successors/manifest
+++ b/11-successors/manifest
@@ -1,0 +1,2 @@
+https://raw.githubusercontent.com/wimpysworld/deb-get/main/11-successors
+trilium

--- a/11-successors/packages/trilium
+++ b/11-successors/packages/trilium
@@ -1,0 +1,22 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+ARCH="${HOST_ARCH}"
+case "${ARCH}" in
+  arm64|aarch64)
+    ARCH=aarch64
+    ;;
+  amd64|x86_64)
+    ARCH=x64
+    ;;
+   *)
+    printf "Unsupported HOST_ARCH: '%s'\n" "${ARCH}"
+    ;;
+esac
+get_github_releases "TriliumNext/Notes" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(grep -E "browser_download_url.*-${ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+    VERSION_PUBLISHED=$(cut -d'/' -f8 <<<"${URL}" | tr -d v)
+fi
+PRETTY_NAME="TriliumNext Notes"
+WEBSITE="https://github.com/TriliumNext/Notes"
+SUMMARY="An open-source, cross-platform hierarchical note taking application with focus on building large personal knowledge bases"


### PR DESCRIPTION
because the package name collides but the fork is consensual, and to avoid forcibly upgrading trilium users to the fork, we could make use of an optional override repo.

Closes #1209 

This draft PR attempts to demonstrate this usage of the facility by creating an additional repository in `11-successors` containing an entry for the `trilium` package pointing to the TriliumNext fork.  In this way the default behaviour leaves `trilium` to use and follow the original repository, but if users want to move to the fork (or choose to install and track the fork) they will need to enable the `11-successors` repository.  For example:

``` shell
head -1 /etc/deb-get/01-main.repo |sed 's/01-main/11-successors/g' |sudo tee /etc/deb-get/11-successors.repo
``` 

This will only work after the repository exists, but then an update will instantiate the new repository override definition and (once the cache for trilium is removed or expires) existing trilium users will get an "upgrade" onto the fork, which will be presented as the only `trilium` package because of the override.  To test this out before the PR is merged (since the CI test is currently broken anyway, and in any case would need extending to enable the `11-successors` repo in the test logic!) it is possible to enable the repo from the PR branch thus:
``` shell
head -1 /etc/deb-get/01-main.repo |sed 's/01-main/11-successors/g;s/wimpysworld/philclifford/;s/\/main\//\/add-triliumnext\//' |sudo tee /etc/deb-get/11-successors.repo
## This is helpful/needed if your cache is still live
# sudo rm /var/cache/deb-get/trilium*
deb-get update
``` 

With the original copied to `99-local.d` under a different name you'd then see something like this and be able to install the fork:

``` text
deb-get show trilium-old trilium
 [...]
  [+] Including local package trilium-old
  [!] Please consider contributing back new entries, an issue (or raise a PR) directly at https://github.com/wimpysworld/deb-get/pulls
Trilium Notes
  Package:	trilium-old
  Repository:	99-local
  Updater:	deb-get
  Installed:	No
  Published:	0.63.7
  Architecture:	amd64
  Download:	https://github.com/zadam/trilium/releases/download/v0.63.7/trilium_0.63.7_amd64.deb
  Website:	https://github.com/zadam/trilium/
  Summary:	Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases.
TriliumNext Notes
  Package:	trilium
  Repository:	11-successors
  Updater:	deb-get
  Installed:	0.90.12
  Published:	0.90.12
  Architecture:	amd64 arm64
  Download:	https://github.com/TriliumNext/Notes/releases/download/v0.90.12/TriliumNextNotes-v0.90.12-linux-x64.deb
  Website:	https://github.com/TriliumNext/Notes
  Summary:	An open-source, cross-platform hierarchical note taking application with focus on building large personal knowledge bases
```

This seems to me the most flexible and respectful approach. 
Of course users are at liberty to take this definition and use it as an override in `99-local` or add it to their own external repository as an override.
