### PR TITLE
fix: add Ubuntu Noble as one of the supported codenames for MasterPDF

### DIFF
--- a/01-main/packages/master-pdf-editor-5
+++ b/01-main/packages/master-pdf-editor-5
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="bionic bullseye buster focal jammy"
+CODENAMES_SUPPORTED="bionic bullseye buster focal jammy noble"
 get_website "https://code-industry.net/get-master-pdf-editor-for-ubuntu/?download"
 if [ "${ACTION}" != "prettylist" ]; then
         URL=$( grep 'document\.location' "${CACHE_FILE}" | grep -Eo "https://code-industry.net/public/.*\.deb" )


### PR DESCRIPTION
closes #1223 