### PR TITLE
Update fastfetch

### DIFF
--- a/01-main/packages/fastfetch
+++ b/01-main/packages/fastfetch
@@ -9,7 +9,7 @@ case $(UPSTREAM_CODENAME) in
         ;;
     *)
         URL=$(grep "browser_download_url.*linux-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | head -n1 | cut -d'"' -f4)
-        ARCHS_SUPPORTED="amd64 arm64 riscv64"
+        ARCHS_SUPPORTED="aarch64 amd64 arm64 riscv64"
         ;;
 esac
 


### PR DESCRIPTION
add missing arch causing an error on Pi devices.

#1137 