### PR TITLE
fix(tribler): re-do fix that was accidentally reverted

### DIFF
--- a/01-main/packages/tribler
+++ b/01-main/packages/tribler
@@ -14,7 +14,7 @@ case "${ARCH}" in
 esac
 get_github_releases "Tribler/tribler" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*_all\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
+    URL=$(grep -m 1 "browser_download_url.*${ARCH}.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
     VERSION_PUBLISHED=$(echo "${URL}" | cut -d'/' -f8 | tr -d v)
 fi
 PRETTY_NAME="Tribler"


### PR DESCRIPTION
The large PR tidying away `head -1` behaviour failed to keep up with some other fixes and effectively reverted this one.


Co-authored-by: Ross Smith II  <ross@smithii.com>