### PR TITLE
refactor: restore consistent use of CACHE_FILE to definitions

### DIFF
--- a/01-main/packages/tixati
+++ b/01-main/packages/tixati
@@ -1,7 +1,7 @@
 DEFVER=1
 get_website "https://www.tixati.com/linux"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 -o  'http.*amd64\.deb\.asc'  /var/cache/deb-get/tixati.html  | sed 's/.asc//')
+    URL=$(grep -m 1 -o  'http.*amd64\.deb\.asc'  "${CACHE_FILE}"  | sed 's/.asc//')
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
 fi
 PRETTY_NAME="Tixati"

--- a/01-main/packages/veracrypt
+++ b/01-main/packages/veracrypt
@@ -7,7 +7,7 @@ case ${HOST_ARCH} in
 esac
 get_website "https://www.veracrypt.fr/en/Downloads.html"
 if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED=$(grep -Eo '/Linux: Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ' /var/cache/deb-get/veracrypt.html | cut -d\  -f3)
+    VERSION_PUBLISHED=$(grep -Eo '/Linux: Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ' "${CACHE_FILE}" | cut -d\  -f3)
 
     URL=$(unroll_url "https://launchpad.net/veracrypt/trunk/${VERSION_PUBLISHED}/+download/veracrypt-${VERSION_PUBLISHED}-${UPSTREAM_ID^}-${UPSTREAM_RELEASE}-${HOST_ARCH}.deb\"")
 fi

--- a/01-main/packages/veracrypt-console
+++ b/01-main/packages/veracrypt-console
@@ -7,7 +7,7 @@ case ${HOST_ARCH} in
 esac 
 get_website "https://www.veracrypt.fr/en/Downloads.html"
 if [ "${ACTION}" != "prettylist" ]; then
-      VERSION_PUBLISHED=$(grep -Eo '/Linux: Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ' /var/cache/deb-get/veracrypt.html | cut -d\  -f3)
+      VERSION_PUBLISHED=$(grep -Eo '/Linux: Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ' "${CACHE_FILE}" | cut -d\  -f3)
 
     URL=$(unroll_url "https://launchpad.net/veracrypt/trunk/${VERSION_PUBLISHED}/+download/veracrypt-console-${VERSION_PUBLISHED}-${UPSTREAM_ID^}-${UPSTREAM_RELEASE}-${HOST_ARCH}.deb\"")
 fi


### PR DESCRIPTION
A few definitions need to be aligned or re-aligned to use CACHE_FILE.