### PR TITLE
fix(hugo): latest release has no packages for reasons

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -60,6 +60,7 @@ dropbox
 du-dust
 duf
 dustracing2d
+eaglemode
 element-desktop
 emby-server
 enpass

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -121,6 +121,7 @@ insync
 ipfs-desktop
 irccloud-desktop
 iriunwebcam
+ivpn-ui
 jabref
 jami
 jc

--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -2,7 +2,7 @@ DEFVER=1
 get_website "https://docs.docker.com/desktop/release-notes/"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep "amd64\.deb" "${CACHE_FILE}" | grep -m 1 -Eo 'https://[^ >]+' | cut -d'?' -f1 | tr -d '"' )"
-    VERSION_PUBLISHED=$(grep -E -m 1 -o 'href=#[0-9]+>[^>]*([^<]*)<' "${CACHE_FILE}" | sed -E 's|.*>([^<]+)<.*|\1|')
+    VERSION_PUBLISHED=$(grep -E -m 1 -o 'href=#[0-9]+>[^>]*([^<]*)<' "${CACHE_FILE}" | head -n 1 | sed -E 's|.*>([^<]+)<.*|\1|')
 fi
 PRETTY_NAME="Docker Desktop"
 WEBSITE="https://www.docker.com/products/docker-desktop/"

--- a/01-main/packages/eaglemode
+++ b/01-main/packages/eaglemode
@@ -1,0 +1,9 @@
+DEFVER=1
+get_website "https://eaglemode.sourceforge.net/download.html"
+if [ "${ACTION}" != prettylist ]; then
+    URL="$(unroll_url "$(grep -m 1 -o "http.*amd64\.deb" "${CACHE_FILE}" )" )"
+    VERSION_PUBLISHED="$(basename "${URL}" .deb | cut -d '_' -f 2)"
+fi
+PRETTY_NAME="Eagle Mode"
+WEBSITE="https://eaglemode.sourceforge.net/"
+SUMMARY="A zoomable user interface (ZUI) with file manager, file viewers, games, and more."

--- a/01-main/packages/hugo
+++ b/01-main/packages/hugo
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-get_github_releases "gohugoio/hugo" "latest"
+get_github_releases "gohugoio/hugo"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v extended | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"

--- a/01-main/packages/indicator-sound-switcher
+++ b/01-main/packages/indicator-sound-switcher
@@ -1,6 +1,10 @@
-DEFVER=1
-PPA="ppa:yktooo/ppa"
+DEFVER=2
+ARCHS_SUPPORTED="amd64 arm64 armhf"
+get_website "https://yktoo.com/en/software/sound-switcher-indicator/download/"
+if [ "${ACTION}" != prettylist ]; then
+    URL="$(grep -o -m 1 "https[^ ]*\.deb" "${CACHE_FILE}")"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d '_' -f 2)"
+fi
 PRETTY_NAME="Sound Switcher Indicator"
-WEBSITE="https://yktoo.com/en/software/sound-switcher-indicator/#software-downloads"
+WEBSITE="https://yktoo.com/en/software/sound-switcher-indicator"
 SUMMARY="Sound input/output selector indicator for Linux."
-

--- a/01-main/packages/ivpn-ui
+++ b/01-main/packages/ivpn-ui
@@ -1,0 +1,9 @@
+DEFVER=1
+# Although the key has a .gpg extension, it's actually in ASCII format.
+ASC_KEY_URL="https://repo.ivpn.net/stable/${UPSTREAM_ID}/generic.gpg"
+APT_LIST_NAME="ivpn"
+APT_REPO_URL="https://repo.ivpn.net/stable/${UPSTREAM_ID} ./generic main"
+APT_REPO_OPTIONS="arch=${HOST_ARCH}"
+PRETTY_NAME="IVPN"
+WEBSITE="https://www.ivpn.net/"
+SUMMARY="Client for IVPN service"

--- a/01-main/packages/smartgit
+++ b/01-main/packages/smartgit
@@ -1,8 +1,9 @@
 DEFVER=1
 get_website "https://www.syntevo.com/smartgit/download/"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="https://www.syntevo.com$(grep -m 1 "\.deb" "${CACHE_FILE}" | cut -d'"' -f2)
+    URL=$(grep -m 1 "\.deb" "${CACHE_FILE}" | cut -d'"' -f2)
     VERSION_PUBLISHED=$(echo "${URL}" | cut -d'-' -f2 | cut -d'.' -f1 | tr '_' '.')
+    VERSION_PUBLISHED=${VERSION_PUBLISHED%%.0}
 fi
 PRETTY_NAME="SmartGit"
 WEBSITE="https://www.syntevo.com/"

--- a/01-main/packages/tribler
+++ b/01-main/packages/tribler
@@ -14,7 +14,7 @@ case "${ARCH}" in
 esac
 get_github_releases "Tribler/tribler" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*_all\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
+    URL=$(grep -m 1 "browser_download_url.*${ARCH}.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
     VERSION_PUBLISHED=$(echo "${URL}" | cut -d'/' -f8 | tr -d v)
 fi
 PRETTY_NAME="Tribler"

--- a/01-main/packages/vuescan
+++ b/01-main/packages/vuescan
@@ -7,7 +7,7 @@ if [ "${ACTION}" != "prettylist" ]; then
         amd64)   ARCH_VER=x64;;
         arm64) ARCH_VER=a64;;
     esac
-    VERSION_PUBLISHED=$(grep -m 1 '<a href="files/vue'${ARCH_VER}'.*\.deb">.*</a>' "${CACHE_FILE}" | cut -d'>' -f2 | cut -d'<' -f1).0-0"
+    VERSION_PUBLISHED=$(grep -m 1 '<a href="files/vue'${ARCH_VER}'.*\.deb">.*</a>' "${CACHE_FILE}" | cut -d'>' -f2 | cut -d'<' -f1)
     local MAJOR_VER=$(echo ${VERSION_PUBLISHED} | cut -d'.' -f1)
     local MINOR_VER=$(echo ${VERSION_PUBLISHED} | cut -d'.' -f2)
     URL="https://www.hamrick.com/files/vue${ARCH_VER}${MAJOR_VER}${MINOR_VER}.deb"

--- a/01-main/packages/webex
+++ b/01-main/packages/webex
@@ -2,7 +2,7 @@ DEFVER=1
 get_website "https://help.webex.com/en-us/article/mqkve8/Webex-App-%7C-Release-notes"
 if [ "${ACTION}" != "prettylist" ]; then
     # Note: get version number from Release Notes
-    VERSION_PUBLISHED=$(grep -o "<p class=\"p\">Linux—[^<]*</p>" "${CACHE_FILE}" | cut -d'>' -f2 | cut -d'<' -f1 | sed 's/Linux—//')
+    VERSION_PUBLISHED=$(grep -m 1 -o "<p class=\"p\">Linux—[^<]*</p>" "${CACHE_FILE}" | cut -d'>' -f2 | cut -d'<' -f1 | sed 's/Linux—//')
 fi
 URL="https://binaries.webex.com/WebexDesktop-Ubuntu-Official-Package/Webex.deb"
 PRETTY_NAME="Webex"

--- a/deb-get
+++ b/deb-get
@@ -168,7 +168,7 @@ function get_github_releases() {
             fancy_message info "Updating ${CACHE_FILE}"
             local URL="https://api.github.com/repos/${1}/releases${2:+/$2}"
             wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps "${URL}" -O- )
-            ${ELEVATE} "${wgetcmdarray[@]}" | sed '/browser_download/!d;/\.deb/!d' >  "${CACHE_FILE}" || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
+            "${wgetcmdarray[@]}" | sed '/browser_download/!d;/\.deb/!d' | ${ELEVATE} tee "${CACHE_FILE}" > /dev/null || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
             if [ -f "${CACHE_FILE}" ] && grep "API rate limit exceeded" "${CACHE_FILE}"; then
                 fancy_message warn "Updating ${CACHE_FILE} exceeded GitHub API limits. Deleting it."
                 ${ELEVATE} rm "${CACHE_FILE}" 2>/dev/null


### PR DESCRIPTION
This removes the latest constraint as they have tagged a source-only version. Now that we trim our cache it may be better to take the cautious approach and stop getting latest tags altogether.

Closes #1237