### PR TITLE
fix(docker-desktop): add head -n 1 to workaround missing LFs in HTML

### DIFF
--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -2,7 +2,7 @@ DEFVER=1
 get_website "https://docs.docker.com/desktop/release-notes/"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep "amd64\.deb" "${CACHE_FILE}" | grep -m 1 -Eo 'https://[^ >]+' | cut -d'?' -f1 | tr -d '"' )"
-    VERSION_PUBLISHED=$(grep -E -m 1 -o 'href=#[0-9]+>[^>]*([^<]*)<' "${CACHE_FILE}" | sed -E 's|.*>([^<]+)<.*|\1|')
+    VERSION_PUBLISHED=$(grep -E -m 1 -o 'href=#[0-9]+>[^>]*([^<]*)<' "${CACHE_FILE}" | head -n 1 | sed -E 's|.*>([^<]+)<.*|\1|')
 fi
 PRETTY_NAME="Docker Desktop"
 WEBSITE="https://www.docker.com/products/docker-desktop/"


### PR DESCRIPTION
Installed fine locally from this PR's file:
`wget https://raw.githubusercontent.com/wimpysworld/deb-get/a5dbc2a36ec44441aa6791b86bd3b497e066c382/01-main/packages/docker-desktop`