### PR TITLE
fix(hugo): latest release has no packages for reasons

### DIFF
--- a/01-main/packages/hugo
+++ b/01-main/packages/hugo
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-get_github_releases "gohugoio/hugo" "latest"
+get_github_releases "gohugoio/hugo"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v extended | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"


### PR DESCRIPTION
This removes the latest constraint as they have tagged a source-only version. Now that we trim our cache it may be better to take the cautious approach and stop getting latest tags altogether.