### PR TITLE
fix(peazip): moved to Qt6

### DIFF
--- a/01-main/packages/peazip
+++ b/01-main/packages/peazip
@@ -1,7 +1,7 @@
 DEFVER=1
-get_github_releases "peazip/PeaZip" "latest"
+get_github_releases "peazip/PeaZip"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -e Qt5 | cut -d'"' -f4)
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -e Qt | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
 fi
 PRETTY_NAME="PeaZip"


### PR DESCRIPTION
This finds the current release with some assumed future-proofing.
Fixes #1284