### PR TITLE
feat: enable plucky support in deb-get

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1381,6 +1381,7 @@ case "${UPSTREAM_CODENAME}" in
     mantic)   UPSTREAM_RELEASE="23.10";;
     noble)    UPSTREAM_RELEASE="24.04";;
     oracular) UPSTREAM_RELEASE="24.10";;
+    plucky)   UPSTREAM_RELEASE="25.04";;
 
     *) fancy_message fatal "${OS_ID_PRETTY} ${OS_CODENAME^} is not supported because it is not derived from a supported Debian or Ubuntu release.";;
 esac


### PR DESCRIPTION
Enable `deb-get` to run on 25.04 when it is released.