### PR TITLE
fix(foliate): change to Github-release method

### DIFF
--- a/01-main/packages/foliate
+++ b/01-main/packages/foliate
@@ -1,5 +1,11 @@
-DEFVER=1
-PPA="ppa:apandada1/foliate"
+DEFVER=2
+CODENAMES_SUPPORTED="trixie sid noble oracular"
+ARCHS_SUPPORTED="amd64 arm64 armhf"
+get_github_releases "johnfactotum/foliate"
+if [ "${ACTION}" != prettylist ]; then
+    URL="$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"
+    VERSION_PUBLISHED="$(cut -d '_' -f 2 <<< "${URL}")"
+fi
 PRETTY_NAME="Foliate"
 WEBSITE="https://johnfactotum.github.io/foliate/"
 SUMMARY="A simple and modern eBook viewer for Linux desktops."


### PR DESCRIPTION
closes #685
Closes #1309

This changes from the PPA to the Github-release method. In doing so, support for Trixie/Sid is added, but it loses support for Focal and Jammy.