### PR TITLE
Fix download link for sejda-desktop

### DIFF
--- a/01-main/packages/sejda-desktop
+++ b/01-main/packages/sejda-desktop
@@ -1,7 +1,7 @@
 DEFVER=1
 get_website "https://www.sejda.com/desktop"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL="https://sejda-cdn.com/downloads/$(grep "linux:" "${CACHE_FILE}" | cut -d"'" -f2)"
+    URL="https://downloads.sejda-cdn.com/$(grep "linux:" "${CACHE_FILE}" | cut -d"'" -f2)"
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
 fi
 PRETTY_NAME="Sejda PDF Desktop"


### PR DESCRIPTION
This PR fixes the download link for Sejda-Desktop. 


closes https://github.com/wimpysworld/deb-get/issues/1332