### PR TITLE
Add Debian support fo ulauncher

### DIFF
--- a/01-main/packages/ulauncher
+++ b/01-main/packages/ulauncher
@@ -1,5 +1,10 @@
 DEFVER=1
-PPA="ppa:agornostal/ulauncher"
+ARCHS_SUPPORTED="amd64 arm64 armhf"
+get_github_releases "Ulauncher/Ulauncher" "latest"
+if [ "${ACTION}" != prettylist ]; then
+    URL="$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"
+    VERSION_PUBLISHED="$(cut -d '_' -f 2 <<< "${URL}")"
+fi
 PRETTY_NAME="Ulauncher"
-WEBSITE="https://ulauncher.io/"
+WEBSITE="https://ulauncher.io"
 SUMMARY="Application launcher for Linux."


### PR DESCRIPTION
Download ulauncher directly from Github. 

Removing PPA repository since it's only supported in Ubuntu and does not work on Debian. 

Fixes https://github.com/wimpysworld/deb-get/issues/1336