### PR TITLE
Update spotify-client pubkey

### DIFF
--- a/01-main/packages/spotify-client
+++ b/01-main/packages/spotify-client
@@ -1,4 +1,4 @@
-DEFVER=2
+DEFVER=3
 ASC_KEY_URL="https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg"
 APT_REPO_URL="http://repository.spotify.com stable non-free"
 PRETTY_NAME="Spotify"

--- a/01-main/packages/spotify-client
+++ b/01-main/packages/spotify-client
@@ -1,5 +1,5 @@
 DEFVER=2
-ASC_KEY_URL="https://download.spotify.com/debian/pubkey_7A3A762FAFD4A51F.gpg"
+ASC_KEY_URL="https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg"
 APT_REPO_URL="http://repository.spotify.com stable non-free"
 PRETTY_NAME="Spotify"
 WEBSITE="https://www.spotify.com/"


### PR DESCRIPTION
update spotify pubkey, fetched on Mar 5, 2025 from https://www.spotify.com/us/download/linux/

**Question** 
Do we need to change anything to remove the old pubkey from systems that already had the old one imported?