### PR TITLE
fix: neohtop: remove dash in manifest name

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -190,7 +190,7 @@ nala
 nekoray
 nemo-mediainfo-tab
 neo4j
-neo-htop
+neohtop
 nextcloud-desktop
 nodejs
 nomad


### PR DESCRIPTION
Fixes:
```
  [!] ERROR! Missing required information of package neo-htop:
DEFVER=
PRETTY_NAME=
SUMMARY=
WEBSITE=
```