### PR TITLE
fix: goreleaser-pro: dpkg: warning: version 'v2.7.0'

### DIFF
--- a/01-main/packages/goreleaser-pro
+++ b/01-main/packages/goreleaser-pro
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64 arm64 armhf i386"
 get_github_releases "goreleaser/goreleaser-pro" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
-    VERSION_PUBLISHED=$(cut -d'/' -f8 <<<"${URL}" | sed -E 's|v([^\-]*)\-(pro)|\1\~\2|')
+    VERSION_PUBLISHED=$(sed -E 's|.*download/v([^/-]+).*|\1|' <<<"${URL}")
 fi
 PRETTY_NAME="Goreleaser Pro"
 WEBSITE="https://goreleaser.com/pro"


### PR DESCRIPTION
Fixes:
```
dpkg: warning: version 'v2.7.0' has bad syntax: version number does not start with digit
```