### PR TITLE
fix; veracrypt{,-console}: URL is blank

### DIFF
--- a/01-main/packages/veracrypt
+++ b/01-main/packages/veracrypt
@@ -7,7 +7,7 @@ case ${HOST_ARCH} in
 esac
 get_website "https://www.veracrypt.fr/en/Downloads.html"
 if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED=$(grep -Eo '/Linux: Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ' "${CACHE_FILE}" | cut -d\  -f3)
+    VERSION_PUBLISHED=$(sed -En 's|.*Latest\s+Stable\s+Release\s*-?\s*(\S+).*|\1|p' "${CACHE_FILE}")
 
     URL=$(unroll_url "https://launchpad.net/veracrypt/trunk/${VERSION_PUBLISHED}/+download/veracrypt-${VERSION_PUBLISHED}-${UPSTREAM_ID^}-${UPSTREAM_RELEASE}-${HOST_ARCH}.deb\"")
 fi

--- a/01-main/packages/veracrypt-console
+++ b/01-main/packages/veracrypt-console
@@ -7,7 +7,7 @@ case ${HOST_ARCH} in
 esac 
 get_website "https://www.veracrypt.fr/en/Downloads.html"
 if [ "${ACTION}" != "prettylist" ]; then
-      VERSION_PUBLISHED=$(grep -Eo '/Linux: Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ' "${CACHE_FILE}" | cut -d\  -f3)
+      VERSION_PUBLISHED=$(sed -En 's|.*Latest\s+Stable\s+Release\s*-?\s*(\S+).*|\1|p' "${CACHE_FILE}")
 
     URL=$(unroll_url "https://launchpad.net/veracrypt/trunk/${VERSION_PUBLISHED}/+download/veracrypt-console-${VERSION_PUBLISHED}-${UPSTREAM_ID^}-${UPSTREAM_RELEASE}-${HOST_ARCH}.deb\"")
 fi


### PR DESCRIPTION
Fixes:
```
  [!] ERROR! Missing required information of website package veracrypt:
URL=https://launchpad.net/veracrypt/trunk//+download/veracrypt--Ubuntu-24.04-amd64.deb
VERSION_PUBLISHED=
  [!] ERROR! Missing required information of website package veracrypt-console:
URL=https://launchpad.net/veracrypt/trunk//+download/veracrypt-console--Ubuntu-24.04-amd64.deb
VERSION_PUBLISHED=
```