### PR TITLE
fix(jellyfin-media-player): remove arch from jellyfin-media-player

### DIFF
--- a/01-main/packages/jellyfin-media-player
+++ b/01-main/packages/jellyfin-media-player
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64"
 CODENAMES_SUPPORTED="bookworm bullseye kinetic jammy focal noble"
 get_github_releases "jellyfin/jellyfin-media-player" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}-${UPSTREAM_CODENAME}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
+    URL=$(grep -m 1 "browser_download_url.*${UPSTREAM_CODENAME}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
     VERSION_PUBLISHED=$(echo "${URL}" | cut -d'/' -f8 | tr -d v)
 fi
 PRETTY_NAME="Jellyfin Media Player"


### PR DESCRIPTION
fixes #1361 