### PR TITLE
feat: Improve Gitlab support

### DIFF
--- a/01-main/packages/glab
+++ b/01-main/packages/glab
@@ -1,23 +1,11 @@
-
 DEFVER=1
-#get_gitlab_releases "34675721" 
-#get_gitlab_releases "gitlab-org%2Fcli" 
-# PROJ="gitlab-org/cli"
-# PROJ=${PROJ/\//%2F}
-#ARCHS_SUPPORTED="amd64 arm64 armhf
+ARCHS_SUPPORTED="amd64 arm64"
 get_gitlab_releases "gitlab-org%2Fcli" "latest"
-
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(jq <${CACHE_FILE} -r '.[] |select(.name|contains("x86_64.deb"))| .direct_asset_url')
-    #URL=$(jq <${CACHE_FILE} --arg arch ${HOST_CPU/armhf/arm} -r '.[] |select(.name|contains($arch))|select(.name|contains(".deb"))| .direct_asset_url')
-
-    #URL= $(jq <${CACHE_FILE} -r '.[] | .direct_asset_url' | grep ".*${HOST_CPU}\.deb"
-    #URL="${URL//\"}"
-
+    URL="$(grep -m 1 -e "${HOST_ARCH}\.deb" -e "${HOST_CPU}\.deb" ${CACHE_FILE})"
     VERSION_PUBLISHED="${URL##*/releases/v}"
     VERSION_PUBLISHED=${VERSION_PUBLISHED%%/*}
 fi
-
 PRETTY_NAME="Glab"
 WEBSITE="https://gitlab.com/gitlab-org/cli"
 SUMMARY="A GitLab CLI tool bringing GitLab to your command line"

--- a/deb-get
+++ b/deb-get
@@ -195,14 +195,21 @@ function get_gitlab_releases() {
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             fancy_message info "Updating ${CACHE_FILE}"
             RELEASE=${2/%latest/permalink/latest}
-
-            local URL="https://gitlab.com/api/v4/projects/${1}/releases/${RELEASE}/assets/links"
+            if [[ ${1} =~ ^https?://.* ]]; then
+                local GITLAB_HOST="$(sed -E 's|(https?://[^/]*).*|\1|' <<< ${1})"
+                local GITLAB_PROJECT="$(sed -E 's|https?://[^/]*/||' <<< ${1})"
+            else
+                local GITLAB_HOST="https://gitlab.com"
+                local GITLAB_PROJECT="${1}"
+            fi
+            local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT}/releases/${RELEASE}/assets/links"
             wgetcmdarray=(wget -q --no-use-server-timestamps "${URL}" -O "${CACHE_FILE}")
 
             ${ELEVATE} "${wgetcmdarray[@]}" || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
         fi
     fi
 }
+
 function get_website() {
     METHOD="website"
     CACHE_FILE="${CACHE_DIR}/${APP}.html"

--- a/deb-get
+++ b/deb-get
@@ -182,7 +182,7 @@ function get_github_releases() {
 
 function get_gitlab_releases() {
     METHOD="gitlab"
-    CACHE_FILE="${CACHE_DIR}/${APP}.json"
+    CACHE_FILE="${CACHE_DIR}/${APP}.json_extract"
     # Cache gitlab releases json for 1 hour to try and prevent API rate limits
     #
     # Do not process gitlab releases while generating a pretty list or upgrading
@@ -202,10 +202,15 @@ function get_gitlab_releases() {
                 local GITLAB_HOST="https://gitlab.com"
                 local GITLAB_PROJECT="${1}"
             fi
-            local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT}/releases/${RELEASE}/assets/links"
-            wgetcmdarray=(wget -q --no-use-server-timestamps "${URL}" -O "${CACHE_FILE}")
-
-            ${ELEVATE} "${wgetcmdarray[@]}" || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
+            if [[ -n "${2}" ]]; then
+                local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases/${RELEASE}/assets/links"
+            else
+                local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases"
+            fi
+            wgetcmdarray=(wget -q --no-use-server-timestamps "${URL}" -O- )
+            # Only grab the .deb files URLs, but first add newlines, because the JSON is all on one line.
+            # This will make it easier for packages to use sed or grep, instead of needing to use jq.
+            "${wgetcmdarray[@]}" | sed -E 's/(\"direct_asset_url\")/\n\1/g; s/(\",)/\1\n/g' | sed -E '/direct_asset_url/!d;/\.deb/!d; s/.*(http.*\.deb).*/\1/' | ${ELEVATE} tee "${CACHE_FILE}" > /dev/null || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
         fi
     fi
 }


### PR DESCRIPTION
This PR makes the following changes:

1. Adds support for self-hosted Gitlab instances.    
    
    You can continue to use  this format if the project is on gitlab.com:
`get_gitlab_releases "<user-organization>/<repository>"`
If the project is hosted elsewhere, you include the full URL instead. For example:
`get_gitlab_releases "https://gitlab.example.com/<user-organization>/<repository>"`
(See also #1390 for an actual example.)  
    
    Gitlab expects slashes in the project name to be URL encoded, but deb-get will now convert them automatically.
So `"<user-organization>/<repository>"` and `"<user-organization>%2F<repository>"` are both valid.

2. Extracts only the lines that contain deb files from the Releases JSON, like we do for Github. 
But I went a step further and removed all of the remaining JSON from those lines. Resulting in the CACHE_FILE containing _only_ the URLs to the deb files. This will reduce the need to use `cut` in the package definition files.

3. Since it's currently the only app using the `get_gitlab_releases` function, I went ahead and updated `glab` to use this simplified CACHE_FILE. I also noticed that they must've changed their naming scheme from `X86_64.deb` to `amd64.deb` at some point, so I grep for both, just in case.