### PR TITLE
Prepare for plucky

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1390,9 +1390,10 @@ case "${UPSTREAM_CODENAME}" in
     sid)      UPSTREAM_RELEASE="unstable";;
     focal)    UPSTREAM_RELEASE="20.04";;
     jammy)    UPSTREAM_RELEASE="22.04";;
-    kinetic)  UPSTREAM_RELEASE="22.10";;
-    lunar)    UPSTREAM_RELEASE="23.04";;
-    mantic)   UPSTREAM_RELEASE="23.10";;
+    # time these unsupported interim releases are removed
+    # kinetic)  UPSTREAM_RELEASE="22.10";;
+    # lunar)    UPSTREAM_RELEASE="23.04";;
+    # mantic)   UPSTREAM_RELEASE="23.10";;
     noble)    UPSTREAM_RELEASE="24.04";;
     oracular) UPSTREAM_RELEASE="24.10";;
     plucky)   UPSTREAM_RELEASE="25.04";;

--- a/deb-get
+++ b/deb-get
@@ -1390,10 +1390,6 @@ case "${UPSTREAM_CODENAME}" in
     sid)      UPSTREAM_RELEASE="unstable";;
     focal)    UPSTREAM_RELEASE="20.04";;
     jammy)    UPSTREAM_RELEASE="22.04";;
-    # time these unsupported interim releases are removed
-    # kinetic)  UPSTREAM_RELEASE="22.10";;
-    # lunar)    UPSTREAM_RELEASE="23.04";;
-    # mantic)   UPSTREAM_RELEASE="23.10";;
     noble)    UPSTREAM_RELEASE="24.04";;
     oracular) UPSTREAM_RELEASE="24.10";;
     plucky)   UPSTREAM_RELEASE="25.04";;

--- a/deb-get
+++ b/deb-get
@@ -3,7 +3,7 @@ LC_ALL=C
 PACKAGE_INSTALLATION_TRIES=0
 PACKAGE_INSTALLATION_COUNT=0
 
-readonly VERSION="0.4.5"
+readonly VERSION="0.4.6"
 
 # set a github auth token (e.g a PAT ) in DEBGET_TOKEN to get a bigger rate limit
 if [ -n "${DEBGET_TOKEN}" ]; then


### PR DESCRIPTION
Just bump the version for release and remove support for unsupported interim releases.
Separate commits to comment out and remove kinetic, lunar and mantic to allow choice.
Still ideally needs a clean `cog` of the 01-main/README.md before triggering a release.