### PR TITLE
fix(hydralauncher): add support for noble and up

### DIFF
--- a/01-main/packages/hydralauncher
+++ b/01-main/packages/hydralauncher
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="bookworm trixie sid jammy"
+CODENAMES_SUPPORTED="bookworm trixie sid jammy noble oracular plucky"
 get_github_releases "hydralauncher/hydra" "latest"
 if [ "${ACTION}" != prettylist ]; then
     URL="$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"


### PR DESCRIPTION
As mentioned [here](https://github.com/wimpysworld/deb-get/issues/1384#issuecomment-2801866964), the sandbox issue in Hydralauncher has been fixed. I was able to install and run the deb in my VMs of Noble, Oracular and the Plucky Prerelease.