### PR TITLE
feat(unroll_url): add support for meta refresh

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -146,6 +146,18 @@ function create_etc_dir() {
 function unroll_url() {
     # Sourceforge started adding parameters
     local TRIM_URL="$(curl -w "%{url_effective}" -I -L -s -S "${1}" -o /dev/null)"
+    #we will only check for the meta refresh if the initial unroll didn't accomplish anything
+    if [[ "${1%/}" == "${TRIM_URL%/}" ]]; then
+        local META_REFRESH="$(wget -q --no-use-server-timestamps "${1}" -O- | grep -E -i -o -m 1 "<meta.*http-equiv=[^\>]*refresh[^\>]*>" | grep -i -E "content=.*url=")"
+        if [[ -n "${META_REFRESH}" ]]; then
+            META_REFRESH="$(sed -E 's|.*url=['\''"]?([^'\''">]*).*|\1|i' <<< "${META_REFRESH}")"
+            if [[ ${META_REFRESH} =~ ^https?://.* ]]; then
+                TRIM_URL="${META_REFRESH}"
+            else
+                TRIM_URL="$(sed -E 's|(https?://[^/]*).*|\1|' <<< ${1})/${META_REFRESH#\/}"
+            fi
+        fi
+    fi
     printf '%s' "${TRIM_URL/\.deb*/.deb}"
 }
 


### PR DESCRIPTION
As mentioned in #1203, `unroll_url` doesn't work on some URLs. One reason for that, is if the site is using the meta refresh tag instead of http redirection. This PR adds support for that.

Here's an example of such a tag:
`<meta http-equiv="refresh" content="1; url=en/download">`