### PR TITLE
Fix incorrect supported architectures for RustDesk

### DIFF
--- a/01-main/packages/rustdesk
+++ b/01-main/packages/rustdesk
@@ -1,12 +1,14 @@
 DEFVER=1
-ARCHS_SUPPORTED="amd64 armv7 aarch64"
+ARCHS_SUPPORTED="amd64 armhf arm64"
 get_github_releases "rustdesk/rustdesk" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${HOST_ARCH}" in
         amd64) URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | grep -m 1 -Ev "$(echo ${ARCHS_SUPPORTED} | tr " " "|")" | cut -d'"' -f4)"
-        ;;
-        *) URL="$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
-        ;;
+            ;;
+        arm64) URL="$(grep -m 1 "browser_download_url.*aarch64\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+            ;;
+        armhf) URL="$(grep -m 1 "browser_download_url.*armv7-sciter\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+            ;;
     esac
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"
 fi

--- a/01-main/packages/rustdesk
+++ b/01-main/packages/rustdesk
@@ -3,11 +3,14 @@ ARCHS_SUPPORTED="amd64 armhf arm64"
 get_github_releases "rustdesk/rustdesk" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${HOST_ARCH}" in
-        amd64) URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | grep -m 1 -Ev "$(echo ${ARCHS_SUPPORTED} | tr " " "|")" | cut -d'"' -f4)"
+        amd64)
+            URL="$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | grep -m 1 -Ev "$(echo ${ARCHS_SUPPORTED} | tr " " "|")" | cut -d'"' -f4)"
             ;;
-        arm64) URL="$(grep -m 1 "browser_download_url.*aarch64\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+        arm64)
+            URL="$(grep -m 1 "browser_download_url.*aarch64\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
             ;;
-        armhf) URL="$(grep -m 1 "browser_download_url.*armv7-sciter\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+        armhf)
+            URL="$(grep -m 1 "browser_download_url.*armv7-sciter\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
             ;;
     esac
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8)"


### PR DESCRIPTION
**_NOTES:_**

- On Debian based distributions, `dpkg --print-architecture` will never:
    - output `aarch64`, but instead will use `arm64`.
    - output `armv7`, but instead will use `armhf`
    - ![Screenshot 2025-04-22 at 2 55 58 PM](https://github.com/user-attachments/assets/c1c474c3-26f9-42cc-a942-2e089e73e101)

---

**_PR NOTES:_**

- For the past year, `armv7` releases for `deb` packages have only ever included `armv7-sciter.deb`. As it stood, the script would never be able to get and install the `deb` for the armv7 architecture.
- As mentioned in the above notes, `dpkg` will never output `aarch64` or `armv7`. As a result, the program would never have been able to install `arm` based systems.

---

**_FINAL NOTES:_**

- I have not been able to test the changes directly, so please review them closely to ensure the `grep` patterns is properly implemented. 
- This PR fixes [issue 1415](https://github.com/wimpysworld/deb-get/issues/1415)
