### PR TITLE
feat: only update cache-file for installed apps

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -164,7 +164,7 @@ function get_github_releases() {
     #   curl -I https://api.github.com/users/flexiondotorg
 
     # Do not process github releases while generating a pretty list or upgrading
-    if [[ ' install update fix-installed ' =~ " ${ACTION} " ]]; then
+    if [[ ' install fix-installed ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             fancy_message info "Updating ${CACHE_FILE}"
             local URL="https://api.github.com/repos/${1}/releases${2:+/$2}"
@@ -193,7 +193,7 @@ function get_gitlab_releases() {
     # So for gitlab sourced apps that use this release model users can use 99-local to pin a version
     #
 
-    if [[ ' install update fix-installed ' =~ " ${ACTION} " ]]; then
+    if [[ ' install fix-installed ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             fancy_message info "Updating ${CACHE_FILE}"
             RELEASE=${2/%latest/permalink/latest}
@@ -220,7 +220,7 @@ function get_gitlab_releases() {
 function get_website() {
     METHOD="website"
     CACHE_FILE="${CACHE_DIR}/${APP}.html"
-    if [[ ' install update fix-installed ' =~ " ${ACTION} " ]]; then
+    if [[ ' install fix-installed ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             fancy_message info "Updating ${CACHE_FILE}"
             # shellcheck disable=SC2086


### PR DESCRIPTION
This PR will make it so that  `deb-get update` will only update the cache file for apps that are already installed.
Unless I'm overlooking something, there doesn't seem to be any need to have the cache file for non-installed apps. When installing an app, it will still be downloaded if needed.

This should significantly reduce the amount that the Github API is being called for the average user, at least partially solving #757. As well as just speeding up the `deb-get update` process overall.

This should also have the side-benefit of reducing the errors shown for apps that are not installed, as mentioned in #964.