### PR TITLE
fix the --remove-repo flag for PPAs

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1174,6 +1174,12 @@ function remove_old_ppa_repo() {
 }
 
 function remove_repo() {
+    if [[ -n "${PPA}" ]]; then
+        local -r PPA_ADDRESS=${PPA#*:}
+        local -r PPA_PERSON=${PPA_ADDRESS%%/*}
+        local -r PPA_ARCHIVE=${PPA_ADDRESS#*/}
+        APT_LIST_NAME="${PPA_PERSON}-ubuntu-${PPA_ARCHIVE}-${UPSTREAM_CODENAME}"
+    fi
     local count=""
     if [ -e "${ETC_DIR}/aptrepos" ]; then
         count="$(grep -m 1 "^${APT_LIST_NAME} " "${ETC_DIR}/aptrepos" | cut -d " " -f 2)"


### PR DESCRIPTION
closes #1420
I basically just copied part of the `ppa_to_apt` function into the `remove_repo` function. 