### PR TITLE
feat(firefox): add Debian support

### DIFF
--- a/01-main/packages/firefox
+++ b/01-main/packages/firefox
@@ -1,11 +1,8 @@
-DEFVER=1
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
-ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
-APT_LIST_NAME="ppa.mozilla.org"
-PPA="ppa:mozillateam/ppa"
+DEFVER=2
+ARCHS_SUPPORTED="amd64 arm64"
+GPG_KEY_ID="C0BA5CE6DC6315A3"
+APT_LIST_NAME="mozilla.org"
+APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox"
 WEBSITE="https://www.mozilla.org/firefox/"
 SUMMARY="Firefox web browser (stable release)."

--- a/01-main/packages/firefox-beta
+++ b/01-main/packages/firefox-beta
@@ -1,9 +1,5 @@
 DEFVER=1
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
-ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
+ARCHS_SUPPORTED="amd64 arm64"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Beta"

--- a/01-main/packages/firefox-devedition
+++ b/01-main/packages/firefox-devedition
@@ -1,9 +1,5 @@
 DEFVER=1
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
-ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
+ARCHS_SUPPORTED="amd64 arm64"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Developer Edition"

--- a/01-main/packages/firefox-esr
+++ b/01-main/packages/firefox-esr
@@ -1,11 +1,19 @@
-DEFVER=1
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
-ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
-APT_LIST_NAME="ppa.mozilla.org"
-PPA="ppa:mozillateam/ppa"
+DEFVER=2
+#Mozilla's apt repo only has an amd64 version of firefox-esr.
+case "${UPSTREAM_ID}" in ubuntu) ARCHS_SUPPORTED="amd64 arm64 armhf";; esac
+case "${HOST_ARCH}" in
+	amd64)
+        ASC_KEY_URL="https://packages.mozilla.org/apt/repo-signing-key.gpg"
+        APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
+        APT_LIST_NAME="mozilla.org"
+        ;;
+	*)
+		PPA="ppa:mozillateam/ppa"
+		;;
+esac
 PRETTY_NAME="Firefox ESR"
 WEBSITE="https://www.mozilla.org/firefox/enterprise/"
 SUMMARY=" Firefox web browser (extended support release)."
+
+
+

--- a/01-main/packages/firefox-nightly
+++ b/01-main/packages/firefox-nightly
@@ -1,9 +1,5 @@
 DEFVER=1
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/main/ :
-ARCHS_SUPPORTED="amd64 arm64 armhf i386 ppc64el riscv64 s390x"
-# Per https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/ :
-# focal groovy gutsy hardy hirsute impish intrepid jammy jaunty kinetic lunar mantic noble oracular trusty xenial zesty
-CODENAMES_SUPPORTED="focal jammy kinetic lunar mantic noble oracular"
+ARCHS_SUPPORTED="amd64 arm64"
 APT_LIST_NAME="mozilla.org"
 APT_REPO_URL="https://packages.mozilla.org/apt mozilla main"
 PRETTY_NAME="Firefox Nightly"


### PR DESCRIPTION
closes #1328
This PR adds Debian support for all of the Firefox packages.
(Note: Most of these use the `GPG_KEY_ID` variable, which currently doesn't work in Sid, Trixie and Plucky.  #1434 should fix that.)

## firefox:
Switches from the PPA to Mozilla's apt repository.
Edited  `ARCHS_SUPPORTED` variable to remove the extra Archs that aren't supported by Mozilla's repo. 
Looking through the [PPA page](https://launchpad.net/~mozillateam/+archive/ubuntu/ppa/+packages?field.name_filter=firefox&field.status_filter=&field.series_filter=), it looks like they've only been building for amd64 and arm64 for a while now. So we aren't actually losing anything by switching.
#1427 would need to be merged in order for this to install properly in Ubuntu Jammy and up. But this is also true of the current firefox package.

## firefox-beta, firefox-nightly, firefox-devedition:
Edited `ARCHS_SUPPORTED` variable to remove the extra Archs that aren't supported by Mozilla's repo. The other Archs were only applicable to the PPA, which these packages never used anyway.
Removed `CODENAMES_SUPPORTED` variable, so that all codenames are supported. I have tested that they all install and run in Buster and up, and Focal and up.

## firefox-esr:
Added Mozilla's apt repo for AMD64 machines. Their repo doesn't have an ARM64 version for firefox-esr, like they do for the other Firefox editions. So for ARM, the PPA will continue to be used.

If desired, I can replace the `PPA="ppa:mozillateam/ppa"` line with 
```
ASC_KEY_URL="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xaebdf4819be21867"
APT_REPO_URL="https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu ${UPSTREAM_CODENAME} main"
APT_LIST_NAME="mozillateam-ubuntu-ppa-${UPSTREAM_CODENAME}"
```
(It's not clear if it was decided to allow splitting methods or not, Since #1295 was merged instead of #1309.
I don't know if that was an intentional decision or perhaps just the first of the two PRs that Martin happened to encounter.)