### PR TITLE
fix(bitwarden): trim version string correctly

### DIFF
--- a/01-main/packages/bitwarden
+++ b/01-main/packages/bitwarden
@@ -2,7 +2,7 @@ DEFVER=1
 get_github_releases "bitwarden/clients"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
-    VERSION_PUBLISHED=$(echo "${URL}" | cut -d'/' -f8 | tr -d desktop-v-)
+    VERSION_PUBLISHED=$(echo "${URL}" | cut -d'/' -f8 | tr -d [=-=][:alpha:])
 fi
 PRETTY_NAME="Bitwarden"
 WEBSITE="https://bitwarden.com/"


### PR DESCRIPTION
Fixes #1445

On the latest Bitwarden Desktop release, `mac` was included in the release tag, even though the .deb was released as well. This commit tweaks the `tr` flags so that any letters and dashes will be trimmed.