### PR TITLE
Remove codename requirement from topgrade

### DIFF
--- a/01-main/packages/topgrade
+++ b/01-main/packages/topgrade
@@ -1,6 +1,5 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-CODENAMES_SUPPORTED="noble plucky trixie sid"
 get_github_releases "topgrade-rs/topgrade" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -E "browser_download_url.*_${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)


### PR DESCRIPTION
Ref #1320, #1398
https://github.com/topgrade-rs/topgrade/pull/1098 was just released in Topgrade v16.0.4. The codename restraints can thus be removed, since https://github.com/topgrade-rs/topgrade/issues/1095 is now fixed.