### PR TITLE
fix(gitkraken): error 404 (fixes #1464)

### DIFF
--- a/01-main/packages/gitkraken
+++ b/01-main/packages/gitkraken
@@ -1,10 +1,10 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64"
 get_website "https://www.gitkraken.com/download/linux-deb"
+URL=$(grep -m 1 -o "https://[^']*\.deb" "${CACHE_FILE}")
 if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED=$(sed -n -E "s/.*name:\s*'([^']*)'.*/\1/p" "${CACHE_FILE}")
 fi
-URL="https://release.gitkraken.com/linux/gitkraken-amd64.deb"
 PRETTY_NAME="GitKraken"
 WEBSITE="https://www.gitkraken.com/git-client"
 SUMMARY="Intuitive Git GUI & powerful Git CLI."


### PR DESCRIPTION
Tested locally, and I'm *still* getting a 404, even though wget downloads the same URL just fine.

And it's not the user agent, so it's some other header that's causing the 404.