### PR TITLE
feat: add support for Virtualbox 7.1 and deprecate old unsupported versions

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -342,7 +342,7 @@ vagrant
 veracrypt
 veracrypt-console
 vfox
-virtualbox-6.1
+#virtualbox-6.1
 virtualbox-7.0
 virtualbox-7.1
 vivaldi-stable

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -344,6 +344,7 @@ veracrypt-console
 vfox
 virtualbox-6.1
 virtualbox-7.0
+virtualbox-7.1
 vivaldi-stable
 vuescan
 waterfox-g-kde

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -343,7 +343,7 @@ veracrypt
 veracrypt-console
 vfox
 #virtualbox-6.1
-virtualbox-7.0
+#virtualbox-7.0
 virtualbox-7.1
 vivaldi-stable
 vuescan

--- a/01-main/packages/virtualbox-7.1
+++ b/01-main/packages/virtualbox-7.1
@@ -1,0 +1,8 @@
+DEFVER=1
+CODENAMES_SUPPORTED="buster bullseye bookworm stretch bionic focal jammy noble oracular"
+ASC_KEY_URL="https://www.virtualbox.org/download/oracle_vbox_2016.asc"
+APT_REPO_URL="https://download.virtualbox.org/virtualbox/debian ${UPSTREAM_CODENAME} contrib"
+APT_REPO_OPTIONS="arch=amd64"
+PRETTY_NAME="VirtualBox 7.1"
+WEBSITE="https://www.virtualbox.org/"
+SUMMARY="VirtualBox 7.1 is a general-purpose full virtualizer for x86 hardware, targeted at server, desktop and embedded use."


### PR DESCRIPTION
This adds support for Virtualbox 7.1 as requested in #1481 but leaves the repo key pointed as instructed in the wiki.

This also deprecates the old unsupported releases of Virtualbox. 

Closes #1487

Note that users of old version should `deb-get remove --remove-repo <old version>` to avoid getting `apt` errors due to conflicting keys (unless they have an override to add "APT_LIST_NAME=virtualbox" to the definition(s) as I suggested a few years back to deal with this).  

Users of older versions could also `deb-get remove <old version>` leaving the repo in place and then simply `sudo apt install virtualbox-7.1` or any of the older versions