### PR TITLE
chore: remove deprecation entry for atuin

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -10,7 +10,6 @@ anydesk
 appimagelauncher
 atom
 atomic
-#atuin
 audio-recorder
 auth
 authme


### PR DESCRIPTION
Atuin Desktop is in beta-testing and generates deprecation messages for testers. Removing the entry from manifest prepares the way for possible support when Atuin Desktop is released.