### PR TITLE
feat: add fooyin

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -97,6 +97,7 @@ firefoxpwa
 flameshot
 flowkeeper
 foliate
+fooyin
 franz
 freeplane
 freeshow

--- a/01-main/packages/fooyin
+++ b/01-main/packages/fooyin
@@ -1,0 +1,12 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+CODENAMES_SUPPORTED="bookworm trixie noble plucky"
+get_github_releases "fooyin/fooyin" "latest"
+
+if [ "${ACTION}" != prettylist ]; then
+    URL="$(grep -m 1 "browser_download_url.*${UPSTREAM_CODENAME}_${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+    VERSION_PUBLISHED=$(cut -d'/' -f8 <<< "${URL}" | tr -d v)
+fi
+PRETTY_NAME="Fooyin"
+WEBSITE="https://fooyin.org/"
+SUMMARY="A customisable music player"


### PR DESCRIPTION
Closes #1187

Although there is a "bookworm" .deb it fails to install on jammy as it has newer dependencies that cannot be resolved.