### PR TITLE
fix(picocrypt-gui):  depends on later libc6 version than available in Bookworm/Jammy

### DIFF
--- a/01-main/packages/picocrypt-gui
+++ b/01-main/packages/picocrypt-gui
@@ -1,5 +1,6 @@
 DEFVER=1
 #ARCHS_SUPPORTED="amd64"
+CODENAMES_SUPPORTED="trixie sid noble oracular plucky"
 get_github_releases "Picocrypt/Picocrypt" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)


### PR DESCRIPTION
Not reflected in deb control so installs but fails to run.
Needs libc6 >=2.38