### PR TITLE
feat: add systemd-manager-tui

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -311,6 +311,7 @@ suwayomi-server
 syft
 syncthing
 system-monitoring-center
+systemd-manager-tui
 tabby-terminal
 tailscale
 tarsnap

--- a/01-main/packages/systemd-manager-tui
+++ b/01-main/packages/systemd-manager-tui
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "matheus-git/systemd-manager-tui" "latest"
+if [ "${ACTION}" != prettylist ]; then
+    URL="$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f4)"
+    VERSION_PUBLISHED="$(cut -d'/' -f8 <<< "${URL}")"
+fi
+PRETTY_NAME="Systemd manager tui"
+WEBSITE="https://github.com/matheus-git/systemd-manager-tui"
+SUMMARY="A program for managing systemd services through a TUI (Terminal User Interfaces)."

--- a/01-main/packages/systemd-manager-tui
+++ b/01-main/packages/systemd-manager-tui
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64 arm64"
 get_github_releases "matheus-git/systemd-manager-tui" "latest"
 if [ "${ACTION}" != prettylist ]; then
     URL="$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f4)"
-    VERSION_PUBLISHED="$(cut -d'/' -f8 <<< "${URL}")"
+    VERSION_PUBLISHED="$(cut -d'/' -f8 <<< "${URL}" | tr -d v)"
 fi
 PRETTY_NAME="Systemd manager tui"
 WEBSITE="https://github.com/matheus-git/systemd-manager-tui"


### PR DESCRIPTION
Systemd manager tui
A program for managing systemd services through a TUI (Terminal User Interfaces).
https://github.com/matheus-git/systemd-manager-tui
