### PR TITLE
fix(docker-desktop): Fix regex for extracting published version

### DIFF
--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64"
 get_website "https://docs.docker.com/desktop/release-notes/"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep -m 1 -o 'https:[^>]*\.deb' "${CACHE_FILE}" )"
-    VERSION_PUBLISHED=$(awk 'match($0, /href=#[0-9][^>]*>([^<]*)</, a) { print a[1]; exit }' "${CACHE_FILE}")
+    VERSION_PUBLISHED=$(grep -oP 'href=#[0-9]+>\K[0-9]+\.[0-9]+\.[0-9]+(?=<)' "${CACHE_FILE}" | head -1)
 fi
 PRETTY_NAME="Docker Desktop"
 WEBSITE="https://www.docker.com/products/docker-desktop/"


### PR DESCRIPTION
#1527 

This pull request updates the logic for extracting the published version number of Docker Desktop from the cached release notes file. The new approach uses a more robust `grep` command with Perl-compatible regular expressions to accurately capture the version string.

Release version extraction improvement:
* Updated the `VERSION_PUBLISHED` assignment in `01-main/packages/docker-desktop` to use `grep -oP` for more precise extraction of the Docker Desktop version number from the release notes cache file.