### PR TITLE
Add nfpm

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -220,6 +220,7 @@ neo4j
 neo-htop
 net.downloadhelper.coapp
 nextcloud-desktop
+nfpm
 nodejs
 nomad
 nordvpn

--- a/01-main/packages/nfpm
+++ b/01-main/packages/nfpm
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "goreleaser/nfpm" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
+fi
+PRETTY_NAME="nFPM"
+WEBSITE="https://nfpm.goreleaser.com/"
+SUMMARY="nFPM is Not FPM - a simple deb, rpm, apk, ipk, and arch linux packager written in Go"


### PR DESCRIPTION
Closes #1462
Went for the GH releases since the apt repository is not using a key and using `trusted=true`. This seems to be unsupported at this time.