### PR TITLE
fix(novelwriter): Limit novelwriter to recent versions

### DIFF
--- a/01-main/packages/novelwriter
+++ b/01-main/packages/novelwriter
@@ -1,4 +1,5 @@
 DEFVER=1
+CODENAMES_SUPPORTED="noble oracular plucky questing"
 get_github_releases "vkbo/novelWriter" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)


### PR DESCRIPTION
"Ubuntu 22.04 is no longer supported. It only has Qt 6.2." (see [here](https://github.com/vkbo/novelWriter/issues/2385#issuecomment-2948319798) )
So we need to limit to versions that will not fail to install with unresolvable dependencies.
 