### PR TITLE
fix(alduin): deprecate alduin

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -2,7 +2,7 @@ https://raw.githubusercontent.com/wimpysworld/deb-get/main/01-main
 1password
 activitywatch
 agena
-alduin
+#alduin
 alsa-scarlett-gui
 android-messages-desktop
 antimicrox


### PR DESCRIPTION
No activity for a couple of years and latest deb fails to install