### PR TITLE
fix(gotop): deprecate gotop

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -125,7 +125,7 @@ google-earth-pro-stable
 goose
 goreleaser
 goreleaser-pro
-gotop
+#gotop
 gpu-viewer
 grub-customizer
 grype


### PR DESCRIPTION
No recent releases on github and the developer
decamped to SourceHut. The last release on github installs with a weird version but whilst it could be kludged it seems better to just deprecate (until a new up-to-date source of deb is found).

-------

```shell
gotop
  Package:	gotop
  Repository:	01-main
  Updater:	deb-get
  Installed:	0.0.0~4.2.0+git
  Published:	4.2.0
```

So if you install it you get updates forever without a fixup.