### PR TITLE
chore: update supported releases - files-cli

### DIFF
--- a/01-main/packages/files-cli
+++ b/01-main/packages/files-cli
@@ -1,6 +1,5 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-CODENAMES_SUPPORTED="buster bullseye bookworm sid focal jammy kinetic lunar mantic noble"
 get_github_releases "Files-com/files-cli" "latest"
 if [ "${ACTION}" != prettylist ]; then
     URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d\" -f 4)


### PR DESCRIPTION
working on #1554