### PR TITLE
chore: update supported releases - tonelib-bassdrive

### DIFF
--- a/01-main/packages/tonelib-bassdrive
+++ b/01-main/packages/tonelib-bassdrive
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="buster bullseye bookworm focal jammy"
+CODENAMES_SUPPORTED="buster bullseye bookworm jammy noble plucky questing"
 get_website "https://www.tonelib.net/downloads.html"
 TLAPP="BassDrive"
 if [ "${ACTION}" != "prettylist" ]; then


### PR DESCRIPTION
working on #1554