### PR TITLE
Fix/update heroic

### DIFF
--- a/01-main/packages/heroic
+++ b/01-main/packages/heroic
@@ -2,7 +2,7 @@ DEFVER=1
 get_github_releases "Heroic-Games-Launcher/HeroicGamesLauncher"
 if [ "${ACTION}" != "prettylist" ]; then
     URL="$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v beta | cut -d'"' -f4)"
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="Heroic Games Launcher"
 WEBSITE="https://heroicgameslauncher.com/"


### PR DESCRIPTION
Fix error in current version, switch to getting the version from the tag path.

Closes #1631.
