### PR TITLE
Update Git Credential Manager package

### DIFF
--- a/01-main/packages/gcm
+++ b/01-main/packages/gcm
@@ -5,10 +5,10 @@ get_github_releases "git-ecosystem/git-credential-manager" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     local ARCH_VER
     case ${HOST_ARCH} in
-        amd64) ARCH_VER=x64;;
+        amd64) ARCH_VER="(x64|amd64)";;
         arm64) ARCH_VER=arm64;;
     esac
-    URL=$(grep -m 1 "browser_download_url.*-${ARCH_VER}-.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
+    URL=$(grep -m1 -E "browser_download_url.*linux[-_]${ARCH_VER}[-.].*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
     VERSION_PUBLISHED=$(echo "${URL}" | cut -d'/' -f8 | tr -d v)
 fi
 PRETTY_NAME="Git Credential Manager"


### PR DESCRIPTION
Starting with revision 2.7.0 gcm is switching the architecture tag to Microsoft .NET format. Also the GitHub repository has ben renamed.
- New Repo: git-ecosystem/git-credential-manager
- Changed Arch amd64 -> x64

This should fix #1663 