### PR TITLE
chore: deprecate popcorn-time

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -264,7 +264,7 @@ plexmediaserver
 plow
 polychromatic
 pomatez
-popcorn-time
+#popcorn-time
 portmaster
 powershell
 protonmail-bridge


### PR DESCRIPTION
It is in process of a complete rewrite.  Leaving definition file in the hope of a simple re-support upon mature release

closes #1666