### PR TITLE
feat: display Github REST API rate limit information

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -171,6 +171,7 @@ function follow_url() {
 function get_github_releases() {
     METHOD="github"
     CACHE_FILE="${CACHE_DIR}/${APP}.json_extract"
+    local HEADERS_FILE="${CACHE_DIR}/${APP}_http_headers"
     # Cache github releases json for 1 hour to try and prevent API rate limits
     #   https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
     #   {"message":"API rate limit exceeded for 62.31.16.154. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
@@ -183,9 +184,30 @@ function get_github_releases() {
                 fancy_message info "Updating ${CACHE_FILE}"
             fi
             local URL="https://api.github.com/repos/${1}/releases${2:+/$2}"
-            wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps "${URL}" -O- )
-            "${wgetcmdarray[@]}" | jq . | ${ELEVATE} tee "${CACHE_FILE}" > /dev/null || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
-            if [ -f "${CACHE_FILE}" ] && grep "API rate limit exceeded" "${CACHE_FILE}"; then
+            wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps --server-response "${URL}" -O- )
+            "${wgetcmdarray[@]}" 2> >("${ELEVATE}" tee "${HEADERS_FILE}" > /dev/null) | jq . | ${ELEVATE} tee "${CACHE_FILE}" > /dev/null || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
+            if grep "401 Unauthorized" "${HEADERS_FILE}"; then
+                fancy_message warn "The DEBGET_TOKEN is invalid or expired."
+            else
+                if [ -z "${DEBGET_TOKEN}" ]; then
+                    fancy_message recommend "DEBGET_TOKEN is not set. To increase your rate limit, create a Github Personal Access Token and put it in the DEBGET_TOKEN environment variable."
+                fi
+                local RATELIMIT_MAX=$(grep -E -o -m1 "X-RateLimit-Limit: [0-9]+" "${HEADERS_FILE}" | cut -d ' ' -f2)
+                local RATELIMIT_RESET=$(grep -E -o -m1 "X-RateLimit-Reset: [0-9]+" "${HEADERS_FILE}" | cut -d ' ' -f2)
+                local RATELIMIT_USED=$(grep -E -o -m1 "X-RateLimit-Used: [0-9]+" "${HEADERS_FILE}" | cut -d ' ' -f2)
+                local RATELIMIT_REMAIN=$(grep -E -o -m1 "X-RateLimit-Remaining: [0-9]+" "${HEADERS_FILE}" | cut -d ' ' -f2)
+                ${ELEVATE} rm "${HEADERS_FILE}" 2>/dev/null
+                if [[ "$RATELIMIT_MAX" =~ ^[0-9]+$ && "$RATELIMIT_RESET" =~ ^[0-9]+$ && "$RATELIMIT_USED" =~ ^[0-9]+$ && "$RATELIMIT_REMAIN" =~ ^[0-9]+$ ]]; then
+                    RATELIMIT_RESET=$((${RATELIMIT_RESET} - $(date +%s)))
+                    if [[ "$RATELIMIT_REMAIN" -lt 1 ]]; then
+                        fancy_message warn "Github API rate limit has been reached. You may experience problems downloading from Github."
+                    fi
+                    fancy_message info "Github API: ${RATELIMIT_USED} request(s) used out of ${RATELIMIT_MAX}. ${RATELIMIT_REMAIN} remaining."
+                    fancy_message info "Github API: Rate limit resets in $((${RATELIMIT_RESET} / 60)) minutes, $((${RATELIMIT_RESET} % 60)) seconds."
+                fi
+            fi
+            if [ -f "${CACHE_FILE}" ] && grep -o "API rate limit exceeded[^\"]*" "${CACHE_FILE}"; then
+                grep -o "https://[^\"]*" "${CACHE_FILE}"
                 fancy_message warn "Updating ${CACHE_FILE} exceeded GitHub API limits. Deleting it."
                 ${ELEVATE} rm "${CACHE_FILE}" 2>/dev/null
             fi

--- a/deb-get
+++ b/deb-get
@@ -185,7 +185,7 @@ function get_github_releases() {
             fi
             local URL="https://api.github.com/repos/${1}/releases${2:+/$2}"
             wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps --server-response "${URL}" -O- )
-            "${wgetcmdarray[@]}" 2> >("${ELEVATE}" tee "${HEADERS_FILE}" > /dev/null) | jq . | ${ELEVATE} tee "${CACHE_FILE}" > /dev/null || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
+            "${wgetcmdarray[@]}" 2> >(${ELEVATE} tee "${HEADERS_FILE}" > /dev/null) | jq . | ${ELEVATE} tee "${CACHE_FILE}" > /dev/null || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
             if grep "401 Unauthorized" "${HEADERS_FILE}"; then
                 fancy_message warn "The DEBGET_TOKEN is invalid or expired."
             else

--- a/deb-get
+++ b/deb-get
@@ -189,7 +189,7 @@ function get_github_releases() {
             if grep "401 Unauthorized" "${HEADERS_FILE}"; then
                 fancy_message warn "The DEBGET_TOKEN is invalid or expired."
             else
-                if [ -z "${DEBGET_TOKEN}" ]; then
+                if [ -z "${DEBGET_TOKEN}" ] && [ -z "${QUIET}" ]; then
                     fancy_message recommend "DEBGET_TOKEN is not set. To increase your rate limit, create a Github Personal Access Token and put it in the DEBGET_TOKEN environment variable."
                 fi
                 local RATELIMIT_MAX=$(grep -E -o -m1 "X-RateLimit-Limit: [0-9]+" "${HEADERS_FILE}" | cut -d ' ' -f2)
@@ -202,8 +202,10 @@ function get_github_releases() {
                     if [[ "$RATELIMIT_REMAIN" -lt 1 ]]; then
                         fancy_message warn "Github API rate limit has been reached. You may experience problems downloading from Github."
                     fi
-                    fancy_message info "Github API: ${RATELIMIT_USED} request(s) used out of ${RATELIMIT_MAX}. ${RATELIMIT_REMAIN} remaining."
-                    fancy_message info "Github API: Rate limit resets in $((${RATELIMIT_RESET} / 60)) minutes, $((${RATELIMIT_RESET} % 60)) seconds."
+                    if [ -z "${QUIET}" ]; then
+                        fancy_message info "Github API: ${RATELIMIT_USED} request(s) used out of ${RATELIMIT_MAX}. ${RATELIMIT_REMAIN} remaining."
+                        fancy_message info "Github API: Rate limit resets in $((${RATELIMIT_RESET} / 60)) minutes, $((${RATELIMIT_RESET} % 60)) seconds."
+                    fi
                 fi
             fi
             if [ -f "${CACHE_FILE}" ] && grep -o "API rate limit exceeded[^\"]*" "${CACHE_FILE}"; then


### PR DESCRIPTION
closes #1630

This PR adds the ability for deb-get to display information about the Github rate limit whenever you install or update an app that installs from Github.

It will show how many requests you have used, how many are remaining, and how many you have total. 
It will also show a reminder if you haven't set a `DEBGET_TOKEN`. If your `DEBGET_TOKEN` is invalid, it will show a message for that too.

Here are some examples of output in different scenarios:


**Trying to install when your DEBGET_TOKEN is invalid:**
```
jet@debian13:~/shared-folder$ ./deb-get install micro
  [+] Updating /var/cache/deb-get/micro.json_extract
  HTTP/1.1 401 Unauthorized
  [*] WARNING! The DEBGET_TOKEN is invalid or expired.
  [*] WARNING! Cached file /var/cache/deb-get/micro.json_extract is empty or missing.
/var/cache/deb-get/: Is a directory
  [!] ERROR! Failed to download . Deleting /var/cache/deb-get/...
```

**Trying to install when the rate limit has been reached:**
```
jet@debian13:~/shared-folder$ ./deb-get install micro
  [+] Updating /var/cache/deb-get/micro.json_extract
  [!] DEBGET_TOKEN is not set. To increase your rate limit, create a Github Personal Access Token and put it in the DEBGET_TOKEN environment variable.
  [*] WARNING! Github API rate limit has been reached. You may experience problems downloading from Github.
  [+] Github API: 60 request(s) used out of 60. 0 remaining.
  [+] Github API: Rate limit resets in 6 minutes, 32 seconds.
API rate limit exceeded for 00.000.00.000. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
  [*] WARNING! Updating /var/cache/deb-get/micro.json_extract exceeded GitHub API limits. Deleting it.
  [*] WARNING! Cached file /var/cache/deb-get/micro.json_extract is empty or missing.
/var/cache/deb-get/: Is a directory
  [!] ERROR! Failed to download . Deleting /var/cache/deb-get/...
```

**Installing without a token set:**
```
jet@debian13:~/shared-folder$ ./deb-get install micro
  [+] Updating /var/cache/deb-get/micro.json_extract
  [!] DEBGET_TOKEN is not set. To increase your rate limit, create a Github Personal Access Token and put it in the DEBGET_TOKEN environment variable.
  [+] Github API: 9 request(s) used out of 60. 51 remaining.
  [+] Github API: Rate limit resets in 13 minutes, 36 seconds.
--2026-02-10 20:52:48--  https://github.com/micro-editor/micro/releases/download/v2.0.13/micro-2.0.13-amd64.deb
Resolving github.com (github.com)... 140.82.112.3
Connecting to github.com (github.com)|140.82.112.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://release-assets.githubusercontent.com/github-production-release-asset/53632140/433b20ff-87b9-4f11-8899-791b5ad176ea?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-02-11T03%3A47%3A17Z&rscd=attachment%3B+filename%3Dmicro-2.0.13-amd64.deb&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-02-11T02%3A46%3A55Z&ske=2026-02-11T03%3A47%3A17Z&sks=b&skv=2018-11-09&sig=r1IEfAlLNtzg4yg0BM14YsPjSc2RwW0sOXWDqNsy8xA%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc3MDc3ODY5NiwibmJmIjoxNzcwNzc4Mzk2LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.7gIuIOW5Wpcf_TARS8AHobMvEOO8GeBO1gm1387aMk8&response-content-disposition=attachment%3B%20filename%3Dmicro-2.0.13-amd64.deb&response-content-type=application%2Foctet-stream [following]
--2026-02-10 20:52:48--  https://release-assets.githubusercontent.com/github-production-release-asset/53632140/433b20ff-87b9-4f11-8899-791b5ad176ea?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-02-11T03%3A47%3A17Z&rscd=attachment%3B+filename%3Dmicro-2.0.13-amd64.deb&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-02-11T02%3A46%3A55Z&ske=2026-02-11T03%3A47%3A17Z&sks=b&skv=2018-11-09&sig=r1IEfAlLNtzg4yg0BM14YsPjSc2RwW0sOXWDqNsy8xA%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc3MDc3ODY5NiwibmJmIjoxNzcwNzc4Mzk2LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.7gIuIOW5Wpcf_TARS8AHobMvEOO8GeBO1gm1387aMk8&response-content-disposition=attachment%3B%20filename%3Dmicro-2.0.13-amd64.deb&response-content-type=application%2Foctet-stream
Resolving release-assets.githubusercontent.com (release-assets.githubusercontent.com)... 185.199.110.133, 185.199.108.133, 185.199.109.133, ...
Connecting to release-assets.githubusercontent.com (release-assets.githubusercontent.com)|185.199.110.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4795244 (4.6M) [application/octet-stream]
Saving to: ‘/var/cache/deb-get/micro-2.0.13-amd64.deb’

/var/cache/deb-get/micro-2.0.13-amd64.deb       100%[====================================================================================================>]   4.57M  3.77MB/s    in 1.2s

2026-02-10 20:52:50 (3.77 MB/s) - ‘/var/cache/deb-get/micro-2.0.13-amd64.deb’ saved [4795244/4795244]

Selecting previously unselected package xclip.
(Reading database ... 216455 files and directories currently installed.)
Preparing to unpack .../xclip_0.13-4_amd64.deb ...
Unpacking xclip (0.13-4) ...
Selecting previously unselected package micro.
Preparing to unpack .../deb-get/micro-2.0.13-amd64.deb ...
Unpacking micro (2.0.13) ...
Setting up micro (2.0.13) ...
Setting up xclip (0.13-4) ...
Processing triggers for man-db (2.13.1-1) ...
```

**Installing with a token:**
```
jet@debian13:~/shared-folder$ ./deb-get install micro
  [+] Updating /var/cache/deb-get/micro.json_extract
  [+] Github API: 1 request(s) used out of 5000. 4999 remaining.
  [+] Github API: Rate limit resets in 60 minutes, 27 seconds.
--2026-02-10 20:54:37--  https://github.com/micro-editor/micro/releases/download/v2.0.13/micro-2.0.13-amd64.deb
Resolving github.com (github.com)... 140.82.114.4
Connecting to github.com (github.com)|140.82.114.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://release-assets.githubusercontent.com/github-production-release-asset/53632140/433b20ff-87b9-4f11-8899-791b5ad176ea?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-02-11T03%3A51%3A47Z&rscd=attachment%3B+filename%3Dmicro-2.0.13-amd64.deb&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-02-11T02%3A51%3A15Z&ske=2026-02-11T03%3A51%3A47Z&sks=b&skv=2018-11-09&sig=UAicBIbIjm8KcH0rXACl94TBZugA0oAjI4Vmm9npPuU%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc3MDc3ODgwNiwibmJmIjoxNzcwNzc4NTA2LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.3EGPhxzWoL3Of3a91KSpp_BL_zd1Av8lez7EaMtZs8c&response-content-disposition=attachment%3B%20filename%3Dmicro-2.0.13-amd64.deb&response-content-type=application%2Foctet-stream [following]
--2026-02-10 20:54:38--  https://release-assets.githubusercontent.com/github-production-release-asset/53632140/433b20ff-87b9-4f11-8899-791b5ad176ea?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-02-11T03%3A51%3A47Z&rscd=attachment%3B+filename%3Dmicro-2.0.13-amd64.deb&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-02-11T02%3A51%3A15Z&ske=2026-02-11T03%3A51%3A47Z&sks=b&skv=2018-11-09&sig=UAicBIbIjm8KcH0rXACl94TBZugA0oAjI4Vmm9npPuU%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc3MDc3ODgwNiwibmJmIjoxNzcwNzc4NTA2LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.3EGPhxzWoL3Of3a91KSpp_BL_zd1Av8lez7EaMtZs8c&response-content-disposition=attachment%3B%20filename%3Dmicro-2.0.13-amd64.deb&response-content-type=application%2Foctet-stream
Resolving release-assets.githubusercontent.com (release-assets.githubusercontent.com)... 185.199.110.133, 185.199.108.133, 185.199.109.133, ...
Connecting to release-assets.githubusercontent.com (release-assets.githubusercontent.com)|185.199.110.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4795244 (4.6M) [application/octet-stream]
Saving to: ‘/var/cache/deb-get/micro-2.0.13-amd64.deb’

/var/cache/deb-get/micro-2.0.13-amd64.deb       100%[====================================================================================================>]   4.57M  5.07MB/s    in 0.9s

2026-02-10 20:54:39 (5.07 MB/s) - ‘/var/cache/deb-get/micro-2.0.13-amd64.deb’ saved [4795244/4795244]

Selecting previously unselected package xclip.
(Reading database ... 216455 files and directories currently installed.)
Preparing to unpack .../xclip_0.13-4_amd64.deb ...
Unpacking xclip (0.13-4) ...
Selecting previously unselected package micro.
Preparing to unpack .../deb-get/micro-2.0.13-amd64.deb ...
Unpacking micro (2.0.13) ...
Setting up micro (2.0.13) ...
Setting up xclip (0.13-4) ...
Processing triggers for man-db (2.13.1-1) ...
```