### PR TITLE
fix:(gb-studio) installing betas and wrong arch

### DIFF
--- a/01-main/packages/gb-studio
+++ b/01-main/packages/gb-studio
@@ -1,8 +1,9 @@
 DEFVER=1
-get_github_releases "chrismaltby/gb-studio"
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "chrismaltby/gb-studio" "latest"
 if [ "${ACTION}" != prettylist ]; then
-    URL="$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"
-    VERSION_PUBLISHED="$(sed -E 's|.*/download/v([^/]*).*|\1|' <<< "${URL}")"
+    URL="$(grep -m 1 "browser_download_url.*${HOST_ARCH//amd64/linux-debian}.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"
+    VERSION_PUBLISHED="$(cut -d '/' -f 8 <<< "${URL//v/}")"
 fi
 PRETTY_NAME="GB Studio"
 WEBSITE="https://www.gbstudio.dev/"


### PR DESCRIPTION
closes #1684
I went ahead and added arm64 to the `ARCHS_SUPPORTED`, since it looks like they will have a new stable release soon.

I also replaced the `sed` in the VERSION_PUBLISHED line with a `cut` and a parameter expansion, which should be more efficient.