### PR TITLE
chore: deprecate gifski

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -114,7 +114,7 @@ ganttproject
 gb-studio
 gcm
 gh
-gifski
+#gifski
 git-delta
 github-desktop
 gitkraken

--- a/01-main/packages/gifski
+++ b/01-main/packages/gifski
@@ -1,9 +1,0 @@
-DEFVER=1
-get_github_releases "ImageOptim/gifski" "latest"
-if [ "${ACTION}" != prettylist ]; then
-    URL="$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"
-    VERSION_PUBLISHED="$(cut -d '_' -f 2 <<< "${URL}")"
-fi
-PRETTY_NAME="Gifski"
-WEBSITE="https://gif.ski/"
-SUMMARY="Gifski makes smooth GIF animations using advanced techniques that work around the GIF format's limitations."


### PR DESCRIPTION
Project no longer produces debs.

There is a snap available.

closes #1709