### PR TITLE
Fix: whatsapp for linux has been renamed and redirected upstream

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -381,6 +381,7 @@ vfox
 virtualbox-7.1
 vivaldi-stable
 vuescan
+wasistlos
 waterfox-g-kde
 wavebox
 waydroid

--- a/01-main/packages/wasistlos
+++ b/01-main/packages/wasistlos
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "xeco23/WasIstLos"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED="$(cut -d '/' -f 8 <<< ${URL//v/})"
+fi
+PRETTY_NAME="WasIstLos"
+WEBSITE="https://github.com/xeco23/WasIstLos"
+SUMMARY="An unofficial WhatsApp desktop application for Linux."

--- a/01-main/packages/whatsapp-for-linux
+++ b/01-main/packages/whatsapp-for-linux
@@ -1,9 +1,0 @@
-DEFVER=1
-get_github_releases "eneshecan/whatsapp-for-linux"
-if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
-    VERSION_PUBLISHED=$(echo "${URL}" | cut -d'_' -f2)
-fi
-PRETTY_NAME="WhatsApp for Linux"
-WEBSITE="https://github.com/eneshecan/whatsapp-for-linux"
-SUMMARY="An unofficial WhatsApp desktop application for Linux."


### PR DESCRIPTION
This deprecates the old app name and adds the new one.

Closes #1719