### PR TITLE
fix(linuxtoys): get app from Codeberg repo

### DIFF
--- a/01-main/packages/linuxtoys
+++ b/01-main/packages/linuxtoys
@@ -1,7 +1,7 @@
 DEFVER=1
 get_website  https://codeberg.org/psygreg/linuxtoys/releases.rss
 if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED=$(grep -m 1 -e 'guid' "${CACHE_FILE}" | cut -d '/' -f 8 | tr -d '<v')
+    VERSION_PUBLISHED=$(grep -m 1 -e 'guid' "${CACHE_FILE}" | sed -n 's#.*releases/tag/v\{0,1\}\([^<]*\).*#\1#p')
     URL="https://codeberg.org/psygreg/linuxtoys/releases/download/${VERSION_PUBLISHED}/linuxtoys_${VERSION_PUBLISHED}-1_${HOST_ARCH}.deb"
 fi
 PRETTY_NAME="LinuxToys"


### PR DESCRIPTION
Application main repo has moved to Codeberg.  
Get version from rss feed and construct URL 
TODO: consider a get_codeberg_releases function as a future approach.

fixes #1707