### PR TITLE
fix(rocketchat): match parsed released version to internal app version

### DIFF
--- a/01-main/packages/rocketchat
+++ b/01-main/packages/rocketchat
@@ -3,7 +3,7 @@ get_github_releases "RocketChat/Rocket.Chat.Electron" "latest"
 # getting latest tag should omit pre-releases. We'll also filter out pre-releases from the list of assets just in case.
 # if we filter out pre-releases we don't need to match the version string by swapping '-' for '~' to get the correct version comparison in apt.
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" <<< $(grep -v -e '-alpha' -e '-beta' -e '-nightly' -e '-rc' "${CACHE_FILE}") | cut -d '"' -f 4 )
+    URL=$(grep -v -e '-alpha' -e '-beta' -e '-nightly' -e '-rc' "${CACHE_FILE}" | grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" | cut -d '"' -f 4 )
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}" ) # | tr '-' '~') 
 fi
 PRETTY_NAME="Rocketchat Desktop"


### PR DESCRIPTION
The actual problem was we were catching alpha pre-release tags.

fixes #1726