### PR TITLE
feat(rpi-imager): add arm64 support

### DIFF
--- a/01-main/packages/rpi-imager
+++ b/01-main/packages/rpi-imager
@@ -1,4 +1,5 @@
 DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
 get_github_releases "raspberrypi/rpi-imager"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep  -m 1 "browser_download_url.*rpi-imager_.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)


### PR DESCRIPTION
Upstream has started building arm64 releases.