### PR TITLE
fix: deprecate homeassistant-supervised

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -141,7 +141,7 @@ headset
 helio-workstation
 helmwave
 heroic
-homeassistant-supervised
+#homeassistant-supervised
 hugo
 hydralauncher
 hyper

--- a/01-main/packages/homeassistant-supervised
+++ b/01-main/packages/homeassistant-supervised
@@ -1,9 +1,0 @@
-DEFVER=1
-get_github_releases "home-assistant/supervised-installer" "latest"
-if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
-fi
-PRETTY_NAME="Home Assistant Supervised"
-WEBSITE="https://github.com/home-assistant/supervised-installer"
-SUMMARY="This is Home Assistant supervised installer, that provides the full Home Assistant experience on a regular operating system."


### PR DESCRIPTION
see [home assistant notice](https://www.home-assistant.io/blog/2025/05/22/deprecating-core-and-supervised-installation-methods-and-32-bit)

closes #1704