### PR TITLE
fix: deprecate soundux

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -317,7 +317,7 @@ smartgit
 sniffnet
 softmaker-office-2021
 songrec
-soundux
+#soundux
 speedtest
 spotify-client
 spotube

--- a/01-main/packages/soundux
+++ b/01-main/packages/soundux
@@ -1,9 +1,0 @@
-DEFVER=1
-get_github_releases "Soundux/Soundux" "latest"
-if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*.deb" "${CACHE_FILE}" | cut -d'"' -f4)
-    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | tr -d v)"
-fi
-PRETTY_NAME="Soundux Soundboard"
-WEBSITE="https://soundux.rocks"
-SUMMARY="Soundux is a cross-platform soundboard compatible with both Pulseaudio and Pipewire. It has a universal architecture and works with a variety of applications such as Discord, Steam, and more."


### PR DESCRIPTION
Last release was 2021. Major rewrite underway for years. On jammy the latest package installs OK but fails to run 

Closes #1703

If/when a new stable release arrives we can re-add.