### PR TITLE
fix: make --quiet flag quieter

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -676,7 +676,7 @@ function update_debs() {
         validate_deb "${APPNAME2FULL[$APP]}"
         if [ "${METHOD}" == "direct" ] || [ "${METHOD}" == "github" ] || [ "${METHOD}" == "gitlab" ] || [ "${METHOD}" == "website" ]; then
             STATUS=$(dpkg-query -Wf '${Status}' "${APP}")
-            if [ "${STATUS}" == "install ok installed" ] && dpkg --compare-versions "${VERSION_PUBLISHED}" gt "${VERSION_INSTALLED}" && [ -z ${QUIET} ]; then
+            if [ "${STATUS}" == "install ok installed" ] && dpkg --compare-versions "${VERSION_PUBLISHED}" gt "${VERSION_INSTALLED}"; then
                 fancy_message info "${APP} (${VERSION_INSTALLED}) has an update pending. ${VERSION_PUBLISHED} is available."
             fi
         fi


### PR DESCRIPTION
closes #1763
This should make `--quiet` fully quiet most of the time. Is that desirable? Or should it still notify when apps have updates available?