### PR TITLE
Add OpenWork package definition

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -253,6 +253,7 @@ onlyoffice-desktopeditors
 openaudible
 openrazer-meta
 openrgb
+openwork
 opera-stable
 os-agent
 ov

--- a/01-main/packages/openwork
+++ b/01-main/packages/openwork
@@ -1,12 +1,8 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
-case ${HOST_ARCH} in
-    amd64) ARCH=amd64 ;;
-    arm64) ARCH=arm64 ;;
-esac
 get_github_releases "different-ai/openwork" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*openwork-desktop-linux-${ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
+    URL=$(grep -m 1 "browser_download_url.*openwork-desktop-linux-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
     VERSION_PUBLISHED=$(echo "${URL}" | cut -d'/' -f8 | tr -d v)
 fi
 PRETTY_NAME="OpenWork"

--- a/01-main/packages/openwork
+++ b/01-main/packages/openwork
@@ -1,0 +1,14 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+case ${HOST_ARCH} in
+    amd64) ARCH=amd64 ;;
+    arm64) ARCH=arm64 ;;
+esac
+get_github_releases "different-ai/openwork" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*openwork-desktop-linux-${ARCH}\.deb\"" "${CACHE_FILE}" | cut -d'"' -f4)
+    VERSION_PUBLISHED=$(echo "${URL}" | cut -d'/' -f8 | tr -d v)
+fi
+PRETTY_NAME="OpenWork"
+WEBSITE="https://openwork.software/"
+SUMMARY="Open-source alternative to Claude Cowork built for teams."


### PR DESCRIPTION
## Summary
- add a new `01-main/packages/openwork` definition for the OpenWork desktop app
- support both `amd64` and `arm64` by selecting the matching GitHub release `.deb` asset
- append `openwork` to `01-main/manifest`

Closes #1773