### PR TITLE
add package: icy-term, icy-draw, icy-view

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -151,6 +151,9 @@ hydralauncher
 hyper
 hyperfine
 i3
+icy-draw
+icy-term
+icy-view
 igdm
 imhex
 indicator-sound-switcher

--- a/01-main/packages/icy-draw
+++ b/01-main/packages/icy-draw
@@ -1,0 +1,24 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+CODENAMES_SUPPORTED="trixie forky sid noble plucky questing resolute"
+MINIMUM_DEB_GET_VERSION="0.4.7"
+# required for post_download
+if ! dpkg --compare-versions "${VERSION}" ge "${MINIMUM_DEB_GET_VERSION}"; then
+    if [ "${ACTION}" == "install" ]; then
+        fancy_message  warn "deb-get Version ${VERSION} does not support $APP. Please use version ${MINIMUM_DEB_GET_VERSION} or later."
+    fi
+    ARCHS_SUPPORTED=""
+fi
+get_github_releases "mkrueger/icy_tools" "" --no-filter
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(grep -m 1 "browser_download_url.*icy_draw_linux.*\.zip\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | sed 's/[^0-9.]//g')"
+fi
+FILE="icy-draw.deb"
+post_download() {
+    ${ELEVATE} unzip -jq "${CACHE_DIR}/${FILE}" "icy_draw.deb" -d "${CACHE_DIR}" || return 1
+    ${ELEVATE} mv "${CACHE_DIR}/icy_draw.deb" "${CACHE_DIR}/${FILE}"
+}
+PRETTY_NAME="IcyDraw"
+WEBSITE="https://github.com/mkrueger/icy_tools/blob/master/crates/icy_draw/README.md"
+SUMMARY="An ANSI/ASCII art editor with support for multiple character sets and file formats."

--- a/01-main/packages/icy-term
+++ b/01-main/packages/icy-term
@@ -1,0 +1,24 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+CODENAMES_SUPPORTED="trixie forky sid noble plucky questing resolute"
+MINIMUM_DEB_GET_VERSION="0.4.7"
+# required for post_download
+if ! dpkg --compare-versions "${VERSION}" ge "${MINIMUM_DEB_GET_VERSION}"; then
+    if [ "${ACTION}" == "install" ]; then
+        fancy_message  warn "deb-get Version ${VERSION} does not support $APP. Please use version ${MINIMUM_DEB_GET_VERSION} or later."
+    fi
+    ARCHS_SUPPORTED=""
+fi
+get_github_releases "mkrueger/icy_tools" "" --no-filter
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(grep -m 1 "browser_download_url.*icy_term_linux.*\.zip\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | sed 's/[^0-9.]//g')"
+fi
+FILE="icy-term.deb"
+post_download() {
+    ${ELEVATE} unzip -jq "${CACHE_DIR}/${FILE}" "icy_term.deb" -d "${CACHE_DIR}" || return 1
+    ${ELEVATE} mv "${CACHE_DIR}/icy_term.deb" "${CACHE_DIR}/${FILE}"
+}
+PRETTY_NAME="IcyTerm"
+WEBSITE="https://github.com/mkrueger/icy_tools/blob/master/crates/icy_term/README.md"
+SUMMARY="A BBS terminal that supports Telnet, SSH, ANSI, Avatar, PETSCII and more."

--- a/01-main/packages/icy-view
+++ b/01-main/packages/icy-view
@@ -1,0 +1,24 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+CODENAMES_SUPPORTED="trixie forky sid noble plucky questing resolute"
+MINIMUM_DEB_GET_VERSION="0.4.7"
+# required for post_download
+if ! dpkg --compare-versions "${VERSION}" ge "${MINIMUM_DEB_GET_VERSION}"; then
+    if [ "${ACTION}" == "install" ]; then
+        fancy_message  warn "deb-get Version ${VERSION} does not support $APP. Please use version ${MINIMUM_DEB_GET_VERSION} or later."
+    fi
+    ARCHS_SUPPORTED=""
+fi
+get_github_releases "mkrueger/icy_tools" "" --no-filter
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(grep -m 1 "browser_download_url.*icy_view_linux.*\.zip\"" "${CACHE_FILE}" | cut -d'"' -f4)"
+    VERSION_PUBLISHED="$(echo "${URL}" | cut -d'/' -f8 | sed 's/[^0-9.]//g')"
+fi
+FILE="icy-view.deb"
+post_download() {
+    ${ELEVATE} unzip -jq "${CACHE_DIR}/${FILE}" "icy_view.deb" -d "${CACHE_DIR}" || return 1
+    ${ELEVATE} mv "${CACHE_DIR}/icy_view.deb" "${CACHE_DIR}/${FILE}"
+}
+PRETTY_NAME="IcyView"
+WEBSITE="https://github.com/mkrueger/icy_tools/blob/master/crates/icy_view/README.md"
+SUMMARY="A viewer for ANSI, ASCII, and other BBS-era art file formats."

--- a/deb-get
+++ b/deb-get
@@ -189,9 +189,8 @@ function get_github_releases() {
                 fancy_message warn "Updating ${CACHE_FILE} exceeded GitHub API limits. Deleting it."
                 ${ELEVATE} rm "${CACHE_FILE}" 2>/dev/null
             fi
-            if [ ! ${APP} == "azuredatastudio" ]; then
-                # because MS have to be different
-                ${ELEVATE} sed -i '/browser_download/!d;/\.deb/!d' ${CACHE_FILE}
+            if [[ " $* " != *' --no-filter '* ]]; then
+                ${ELEVATE} sed -i "/browser_download/!d;/\.deb/!d" ${CACHE_FILE}
             fi
         fi
     fi


### PR DESCRIPTION
[mkrueger/icy_tools](https://github.com/mkrueger/icy_tools) is a mono-repository that releases 3 apps: `icy-term`, `icy-draw` and `icy-view`. Moreover, instead of uploading a `.deb` file directly as a release asset, they upload `.zip` files that contain the `.deb` file. Therefore I had to make some small changes to the `deb-get` main script in order to support this setup.