### PR TITLE
fix:(rstudio) fix installation in Mint & other distros

### DIFF
--- a/01-main/packages/rstudio
+++ b/01-main/packages/rstudio
@@ -1,27 +1,25 @@
 DEFVER=1
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing"
-get_website "https://posit.co/download/rstudio-desktop/"
+get_website "https://posit.co/wp-content/uploads/downloads.json"
+local RELEASE
+local CODENAME
+local ALL_RELEASES
 if [ "${ACTION}" != "prettylist" ]; then
+    ALL_RELEASES=$(jq -r '.rstudio.open_source.stable.desktop.installer[] | select(.platform.name | contains("Ubuntu") or contains("Debian")) | [.platform.name, .platform.key] | join(",")' "${CACHE_FILE}")
     case "${UPSTREAM_CODENAME}" in
-        bookworm|jammy|noble)
-            # Only these are present currently. Focal has been removed. Both currently point to jammy/bookworm builds.
-            #
-            URL=$(grep -A4 -e "${OS_ID} ${UPSTREAM_RELEASE%%.*}"  $CACHE_FILE |grep -m 1 -E -o "https://.*${HOST_ARCH}\.deb" )
-            ;;
-        plucky|questing)
-        # On the assumption that these will use 24 when a newer build is available.
-            URL=$(grep -A4 -e "${OS_ID} 24"  $CACHE_FILE |grep -m 1 -E -o "https://.*${HOST_ARCH}\.deb" )
-            ;;
-        forky|sid|trixie)
-        # currently only 12 is available. Amend when more are added.
-            URL=$(grep -A4 -e "${OS_ID} 12"  $CACHE_FILE |grep -m 1 -E -o "https://.*${HOST_ARCH}\.deb" )
-            ;;
-        *)
-        # Default to Ubuntu 22.04 build for other distros
-            URL=$(grep -A4 -e "Ubuntu 22"  $CACHE_FILE |grep -m 1 -E -o "https://.*${HOST_ARCH}\.deb" )
-            ;;
+        sid) RELEASE=$(grep -E -o "Debian [0-9]+" <<< "${ALL_RELEASES}" | cut -d ' ' -f2 | sort -rn | head -n1);;
+          *) RELEASE="${UPSTREAM_RELEASE%%.*}";;
     esac
-    VERSION_PUBLISHED=$(cut -d '-' -f 2-3 <<< "${URL}" | tr - +)
+    while [[ ${RELEASE} -gt 0 ]]; do
+        CODENAME=$(grep -i -m 1 -E -o "${UPSTREAM_ID} ${RELEASE}[^,]*,[[:alnum:]]+" <<< "${ALL_RELEASES}")
+        if [[ ${CODENAME} =~ ${UPSTREAM_ID^}\ ${RELEASE}[^,]*,[a-z]+ ]]; then break; fi
+        RELEASE=$((RELEASE - 1))
+    done
+    CODENAME=$(cut -d ',' -f2 <<< "${CODENAME}")
+    if [ -n "${CODENAME}" ]; then
+        URL=$(jq -r ".rstudio.open_source.stable.desktop.installer.${CODENAME}.url" "${CACHE_FILE}")
+        VERSION_PUBLISHED=$(jq -r ".rstudio.open_source.stable.desktop.installer.${CODENAME}.version" "${CACHE_FILE}")
+    fi
 fi
 PRETTY_NAME="RStudio"
 WEBSITE="https://posit.co/"

--- a/01-main/packages/rstudio-server
+++ b/01-main/packages/rstudio-server
@@ -1,18 +1,25 @@
 DEFVER=1
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing"
-get_website "https://posit.co/download/rstudio-server/"
+get_website "https://posit.co/wp-content/uploads/downloads.json"
+local RELEASE
+local CODENAME
+local ALL_RELEASES
 if [ "${ACTION}" != "prettylist" ]; then
+    ALL_RELEASES=$(jq -r '.rstudio.open_source.stable.server.installer[] | select(.platform.name | contains("Ubuntu") or contains("Debian")) | [.platform.name, .platform.key] | join(",")' "${CACHE_FILE}")
     case "${UPSTREAM_CODENAME}" in
-        trixie|sid|forky|noble|plucky|questing)
-        # only jammy build available for now
-        # later releases may get their own builds - amend when that happens
-            URL=$(grep -m 1 -o -E "wget.*jammy.*${HOST_ARCH}\.deb" "${CACHE_FILE}" | cut -d ' ' -f 2)
-            ;;
-        *)
-            URL=$(grep -m 1 -o -E "wget.*jammy.*${HOST_ARCH}\.deb" "${CACHE_FILE}" | cut -d ' ' -f 2)
-            ;;
+        sid) RELEASE=$(grep -E -o "Debian [0-9]+" <<< "${ALL_RELEASES}" | cut -d ' ' -f2 | sort -rn | head -n1);;
+          *) RELEASE="${UPSTREAM_RELEASE%%.*}";;
     esac
-    VERSION_PUBLISHED=$(grep -E -o '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\-[[:digit:]]+' <<< "${URL}" | tr - +)
+    while [[ ${RELEASE} -gt 0 ]]; do
+        CODENAME=$(grep -i -m 1 -E -o "${UPSTREAM_ID} ${RELEASE}[^,]*,[[:alnum:]]+" <<< "${ALL_RELEASES}")
+        if [[ ${CODENAME} =~ ${UPSTREAM_ID^}\ ${RELEASE}[^,]*,[a-z]+ ]]; then break; fi
+        RELEASE=$((RELEASE - 1))
+    done
+    CODENAME=$(cut -d ',' -f2 <<< "${CODENAME}")
+    if [ -n "${CODENAME}" ]; then
+        URL=$(jq -r ".rstudio.open_source.stable.server.installer.${CODENAME}.url" "${CACHE_FILE}")
+        VERSION_PUBLISHED=$(jq -r ".rstudio.open_source.stable.server.installer.${CODENAME}.version" "${CACHE_FILE}")
+    fi
 fi
 PRETTY_NAME="RStudio Server"
 WEBSITE="https://posit.co"


### PR DESCRIPTION
closes #1766

> I see the problem. The package definition file uses `$OS_ID` when it greps for the URL. As a result, it will only work properly on Debian or Ubuntu, and not on any other distro. Replacing `$OS_ID` with `$UPSTREAM_ID` will probably be enough to fix it. 
> 
> However, looking at the website, I notice that they actually use the exact same .deb file for all of the .deb-based distros that they support. So it should be possible to simplify the package. I'll make a PR soon. 

 _Originally posted by @silentJET85 in [#1766](https://github.com/wimpysworld/deb-get/issues/1766#issuecomment-4043085570)_