### PR TITLE
feat: restore surfshark support

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -334,7 +334,7 @@ sublime-merge
 sublime-text
 superproductivity
 sunshine
-#surfshark
+surfshark
 suwayomi-server
 syft
 syncthing

--- a/01-main/packages/surfshark
+++ b/01-main/packages/surfshark
@@ -1,0 +1,9 @@
+DEFVER=1
+get_website https://aur.archlinux.org/packages/surfshark-client
+if [ "${ACTION}" != "prettylist" ]; then
+    VERSION_PUBLISHED=$(grep -m 1 'Package Details' "${CACHE_FILE}" |  grep -o -E '([[:digit:]]+\.)+[[:digit:]]+' )
+    URL="https://ocean.surfshark.com/debian/pool/main/s/surfshark_${VERSION_PUBLISHED}_${HOST_ARCH}.deb"
+fi
+PRETTY_NAME="Surfshark VPN"
+WEBSITE="https://surfshark.com/"
+SUMMARY="Award-winning VPN service."


### PR DESCRIPTION
cheeky use of AUR to find latest version suggested by

https://github.com/wimpysworld/deb-get/issues/1728#issuecomment-4073618896

It remains to be seen if SurfShark keep packaging debs, and whether the AUR keeps up with the `flatpak` and `snap` releases 