### PR TITLE
chore: fix shellcheck warnings

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1693,6 +1693,9 @@ export CACHE_DIR="/var/cache/deb-get"
 readonly ETC_DIR="/etc/deb-get"
 readonly MAIN_REPO_URL="https://raw.githubusercontent.com/wimpysworld/deb-get/main/01-main"
 
+# shellcheck disable=SC2034
+readonly USER_AGENT="Mozilla/5.0 (X11; Linux ${HOST_CPU}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36"
+
 readonly DEBGET_BIN=$(basename $0)
 
 parse_machine


### PR DESCRIPTION
This addresses all of the remaining Shellcheck warnings.  In detail:

* Globally disable shellcheck [SC2076](https://www.shellcheck.net/wiki/SC2076), since we intentionally use `=~` to match strings in several places.

* Globally disable shellcheck [SC2155](https://www.shellcheck.net/wiki/SC2155), since we create and assign local variables in a single command in several places. We aren't checking the exit codes of them anyway, so them being masked doesn't seem to be relevant. 

* In the `update_repos` function, disable shellcheck [SC2034](https://www.shellcheck.net/wiki/SC2034), because it can't tell that `$CURL_OPTS` is used within a string passed to `eval`.

* In the `update_repos` function, add an `if` statement to the `pushd` command to address [SC2164](https://www.shellcheck.net/wiki/SC2164). Since `popd` now only runs if `pushd` was successful, there's not really any chance of it going to the wrong directory. So I simply added `|| true` to shut shellcheck up.
    
* In the `validate_deb` function, set shellsheck source to /dev/null, since we are sourcing a file that it has no way of knowing. [SC1090](https://www.shellcheck.net/wiki/SC1090)

* In the `refresh_supported_cache_lists` function, replace the double quotes around the `trap` command with single quotes. Probably not a big deal, but it makes shellcheck happy. [SC2064](https://www.shellcheck.net/wiki/SC2064)

* In the `dg_action_update` function, add double quotes to the `$INSTALLED_APPS` array to address [SC2206](https://www.shellcheck.net/wiki/SC2206).

* In the `upgrade_only_dg` function, change the grep command to avoid the need for parameter expansion afterwards. It had the same [SC2206](https://www.shellcheck.net/wiki/SC2206) issue as above.

* In the `parse_machine` function, disable shellcheck [SC2034](https://www.shellcheck.net/wiki/SC2034) for the `$DEBIAN_TESTING` variable, since it is only used in package definition files.

* Remove unused variables `$USER_AGENT`and `$USER_HOME`. [SC2034](https://www.shellcheck.net/wiki/SC2034)
