### PR TITLE
fix(qownnotes): can't install in Trixie

### DIFF
--- a/01-main/packages/qownnotes
+++ b/01-main/packages/qownnotes
@@ -1,28 +1,25 @@
 DEFVER=2
 ARCHS_SUPPORTED="amd64 arm64 armhf"
-local THE_KEY
-local THE_REPO
 case ${UPSTREAM_ID} in
     ubuntu)
-        THE_KEY="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x54223c6547878405"
-        THE_REPO="https://ppa.launchpadcontent.net/pbek/qownnotes/ubuntu ${UPSTREAM_CODENAME} main"
+        ASC_KEY_URL="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x54223c6547878405"
+        APT_REPO_URL="https://ppa.launchpadcontent.net/pbek/qownnotes/ubuntu ${UPSTREAM_CODENAME} main"
         ;;
     *)
-        local DEBIANVER
-        local THE_OPTIONS
-        case ${UPSTREAM_CODENAME} in
-            sid|13|trixie) DEBIANVER=Unstable ;;
-            *) DEBIANVER=${UPSTREAM_RELEASE} ;;
-        esac
-        THE_KEY="http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_${DEBIANVER}/Release.key"
-        THE_REPO="http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_${DEBIANVER}/ /"
-        THE_OPTIONS="arch=${HOST_ARCH}"
+        # the armhf and arm64 builds are currently missing for Debian 13. They previously had the same problem with Debian 12.
+        # If missing, we fall back to the repo of the previous Debian. This also allows it to work in Debian Testing.
+        while [[ "${UPSTREAM_RELEASE}" != "unstable" && "${UPSTREAM_RELEASE}" -gt 0 ]]; do
+            if wget -q --spider "http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_${UPSTREAM_RELEASE}/${HOST_ARCH}"; then
+                break
+            else
+                ((UPSTREAM_RELEASE--))
+            fi
+        done
+        ASC_KEY_URL="http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_${UPSTREAM_RELEASE^}/Release.key"
+        APT_REPO_URL="http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_${UPSTREAM_RELEASE^}/ /"
+        APT_REPO_OPTIONS="arch=${HOST_ARCH}"
         ;;
 esac
-
-ASC_KEY_URL="${THE_KEY}"
-APT_REPO_URL="${THE_REPO}"
-APT_REPO_OPTIONS="${THE_OPTIONS}"
 APT_LIST_NAME=qownnotes
 PRETTY_NAME="QOwnNotes"
 WEBSITE="https://www.qownnotes.org"


### PR DESCRIPTION
closes #1806
The repo for Debian 13 is missing the arm builds, and I'm [not sure](https://github.com/pbek/QOwnNotes/issues/3199#issuecomment-4092781847) if they're going to be added. So I made it fall back to the previous Debian's repo if it can't find the current one. It seems to work fine.