### PR TITLE
fix(git-delta): only released musl version upstream

### DIFF
--- a/01-main/packages/git-delta
+++ b/01-main/packages/git-delta
@@ -1,6 +1,7 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armhf"
-get_github_releases "dandavison/delta" "latest"
+get_github_releases "dandavison/delta"
+# "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v musl | cut -d'"' -f4)
     VERSION_PUBLISHED="$(echo "${URL}" | cut -d'_' -f2)"


### PR DESCRIPTION
We need to wait on the last released non-musl deb (it may arrive later in the latest release). We cannot just grab the musl deb as the application name is `git-delta-musl`
fixes #1810 