### PR TITLE
feat: add deltachat-tauri package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -56,6 +56,7 @@ deadbeef-static
 #deborah
 deemix
 deltachat-desktop
+deltachat-tauri
 deskcut
 deskflow
 deskreen-ce

--- a/01-main/packages/deltachat-tauri
+++ b/01-main/packages/deltachat-tauri
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_github_releases "deltachat/deltachat-desktop" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*deltachat-tauri_.*_amd64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "$(basename "${URL}")")
+fi
+PRETTY_NAME="Delta Chat (Tauri)"
+WEBSITE="https://delta.chat"
+SUMMARY="Email-based decentralized messenger (Tauri desktop client)."


### PR DESCRIPTION
## Summary

Adds the Tauri-based Delta Chat desktop client. This is the newer Tauri version alongside the existing Electron-based `deltachat-desktop` package.

## Changes

- `01-main/packages/deltachat-tauri`: Package definition targeting `deltachat-tauri_*_amd64.deb` from deltachat/deltachat-desktop releases
- `01-main/manifest`: Added `deltachat-tauri` in alphabetical order

## Testing

Verified the GitHub release at deltachat/deltachat-desktop contains `deltachat-tauri_*_amd64.deb` matching the grep pattern. Package definition based on the working config provided in the issue.

Closes #1786

This contribution was developed with AI assistance (Claude Code).