### PR TITLE
feat: add support for Deb822 (.sources files)

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1323,12 +1323,12 @@ function add_apt_repo() {
         fi
         APT_SOURCES_LINES+=("Signed-By: /usr/share/keyrings/${APT_LIST_NAME}-archive-keyring.gpg")
         if [[ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" ]]; then
-            fancy_message info "Removing /etc/apt/sources.list.d/${APT_LIST_NAME}.list"
-            ${ELEVATE} rm "/etc/apt/sources.list.d/${APT_LIST_NAME}.list"
+            fancy_message info "Renaming /etc/apt/sources.list.d/${APT_LIST_NAME}.list to ${APT_LIST_NAME}.list.bak"
+            ${ELEVATE} mv "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" "/etc/apt/sources.list.d/${APT_LIST_NAME}.list.bak"
         fi
         printf '%s\n' "${APT_SOURCES_LINES[@]}" | ${ELEVATE} tee "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" > /dev/null
 
-    else
+    elif ! [[ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" ]]; then
         # single line .list format
         local APT_LIST_LINE="deb [signed-by=/usr/share/keyrings/${APT_LIST_NAME}-archive-keyring.gpg"
 
@@ -1337,10 +1337,6 @@ function add_apt_repo() {
         fi
 
         APT_LIST_LINE="${APT_LIST_LINE}] ${APT_REPO_URL}"
-        if [[ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" ]]; then
-            fancy_message info "Removing /etc/apt/sources.list.d/${APT_LIST_NAME}.sources"
-            ${ELEVATE} rm "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources"
-        fi
         ${ELEVATE} tee "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" <<<"${APT_LIST_LINE}" >/dev/null
     fi
 }

--- a/deb-get
+++ b/deb-get
@@ -324,8 +324,9 @@ function upgrade_only_dg() {
 
 # Update only the added repo (during install action)
 function update_only_repo() {
-    fancy_message info "Updating: /etc/apt/sources.list.d/${APT_LIST_NAME}.list"
-    ${ELEVATE} apt-get update -o Dir::Etc::sourcelist="sources.list.d/${APT_LIST_NAME}.list" \
+    if [[ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" ]]; then local EXT="sources"; else local EXT="list"; fi
+    fancy_message info "Updating: /etc/apt/sources.list.d/${APT_LIST_NAME}.${EXT}"
+    ${ELEVATE} apt-get update -o Dir::Etc::sourcelist="sources.list.d/${APT_LIST_NAME}.${EXT}" \
         -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
 }
 
@@ -1219,6 +1220,7 @@ function remove_repo() {
         local -r PPA_ARCHIVE=${PPA_ADDRESS#*/}
         APT_LIST_NAME="${PPA_PERSON}-ubuntu-${PPA_ARCHIVE}-${UPSTREAM_CODENAME}"
     fi
+    if [[ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" ]]; then local EXT="sources"; else local EXT="list"; fi
     local count=""
     if [ -e "${ETC_DIR}/aptrepos" ]; then
         count="$(grep -m 1 "^${APT_LIST_NAME} " "${ETC_DIR}/aptrepos" | cut -d " " -f 2)"
@@ -1238,14 +1240,15 @@ function remove_repo() {
             fi
             ${ELEVATE} rm -f "/usr/share/keyrings/${APT_LIST_NAME}-archive-keyring.gpg"
             if [ "${2}" != --quiet ]; then
-                fancy_message info "Removing /etc/apt/sources.list.d/${APT_LIST_NAME}.list"
+                fancy_message info "Removing /etc/apt/sources.list.d/${APT_LIST_NAME}.${EXT}"
             fi
-            ${ELEVATE} rm -f "/etc/apt/sources.list.d/${APT_LIST_NAME}.list"
+            ${ELEVATE} rm -f "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" 2> /dev/null
+            ${ELEVATE} rm -f "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" 2> /dev/null
             if [ -e "${ETC_DIR}/aptrepos" ]; then
                 ${ELEVATE} sed -i -E "/^${APT_LIST_NAME} [0-9]+/d" "${ETC_DIR}/aptrepos"
             fi
         elif [ "${2}" != --quiet ]; then
-            fancy_message warn "/etc/apt/sources.list.d/${APT_LIST_NAME}.list was not removed because other packages depend on it."
+            fancy_message warn "/etc/apt/sources.list.d/${APT_LIST_NAME}.${EXT} was not removed because other packages depend on it."
         fi
     fi
 }
@@ -1259,7 +1262,7 @@ function add_apt_repo() {
         if [ -z "${count}" ]; then
             count=0
         fi
-        if [ "${count}" -eq 0 ] && [ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" ]; then
+        if [ "${count}" -eq 0 ] && { [ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" ] || [ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" ]; }; then
             ((count++))
         fi
         ((count++))
@@ -1292,14 +1295,54 @@ function add_apt_repo() {
         fi
     fi
 
-    local APT_LIST_LINE="deb [signed-by=/usr/share/keyrings/${APT_LIST_NAME}-archive-keyring.gpg"
+    if [[ "${DEBGET_SOURCES}" == "sources" ]]; then
+        # Deb822 .sources format
+        local URL="$(cut -d ' ' -f 1 <<< "${APT_REPO_URL}")"
+        local SUITES="$(cut -d ' ' -f 2 <<< "${APT_REPO_URL}")"
+        local COMPONENTS="$(cut -d ' ' -f 3- <<< "${APT_REPO_URL}")"
+        local APT_SOURCES_LINES=("Enabled: yes" "Types: deb" "URIs: ${URL}" "Suites: ${SUITES}")
+        if ! [[ "${SUITES}" =~ /$ ]] && [[ -n "${COMPONENTS}" ]]; then
+            APT_SOURCES_LINES+=("Components: ${COMPONENTS}")
+        fi
+        if [[ -n "${APT_REPO_OPTIONS}" ]]; then
+            local option
+            for option in ${APT_REPO_OPTIONS}; do
+                case "${option}" in
+                    arch=*)
+                        option="${option/arch/Architectures}";;
+                    lang=*)
+                        option="${option/lang/Languages}";;
+                    target=*)
+                        option="${option/target/Targets}";;
+                    *)
+                        option="$(cut -d '=' -f1 <<< "${option}" | sed -E 's/(^|[- ])([a-z])/\1\u\2/g')=$(cut -d '=' -f 2 <<< "${option}")";;
+                esac
+                option="${option/=/: }"; option="${option//,/ }"
+                APT_SOURCES_LINES+=("${option}")
+            done
+        fi
+        APT_SOURCES_LINES+=("Signed-By: /usr/share/keyrings/${APT_LIST_NAME}-archive-keyring.gpg")
+        if [[ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" ]]; then
+            fancy_message info "Removing /etc/apt/sources.list.d/${APT_LIST_NAME}.list"
+            ${ELEVATE} rm "/etc/apt/sources.list.d/${APT_LIST_NAME}.list"
+        fi
+        printf '%s\n' "${APT_SOURCES_LINES[@]}" | ${ELEVATE} tee "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" > /dev/null
 
-    if [ -n "${APT_REPO_OPTIONS}" ]; then
-        APT_LIST_LINE="${APT_LIST_LINE} ${APT_REPO_OPTIONS}"
+    else
+        # single line .list format
+        local APT_LIST_LINE="deb [signed-by=/usr/share/keyrings/${APT_LIST_NAME}-archive-keyring.gpg"
+
+        if [ -n "${APT_REPO_OPTIONS}" ]; then
+            APT_LIST_LINE="${APT_LIST_LINE} ${APT_REPO_OPTIONS}"
+        fi
+
+        APT_LIST_LINE="${APT_LIST_LINE}] ${APT_REPO_URL}"
+        if [[ -e "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources" ]]; then
+            fancy_message info "Removing /etc/apt/sources.list.d/${APT_LIST_NAME}.sources"
+            ${ELEVATE} rm "/etc/apt/sources.list.d/${APT_LIST_NAME}.sources"
+        fi
+        ${ELEVATE} tee "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" <<<"${APT_LIST_LINE}" >/dev/null
     fi
-
-    APT_LIST_LINE="${APT_LIST_LINE}] ${APT_REPO_URL}"
-    ${ELEVATE} tee "/etc/apt/sources.list.d/${APT_LIST_NAME}.list" <<<"${APT_LIST_LINE}" >/dev/null
 }
 
 function ppa_to_apt() {


### PR DESCRIPTION
closes #1816
EDIT: (I reworked this. See latest posts down below.)

This adds optional support for the newer Deb822 `.sources` files. Existing support for `.list` files is not affected.

~~These new variables are used in a package to create a `.sources` file:~~
~~* `APT_SOURCES_URL` This contains the URL to the repository. This variable being set is also what tells deb-get to use the new format.~~
~~* `APT_SUITES` This contains the suite(s). Equivalent to the "word" after the URL in the old format.~~
~~* `APT_COMPONENTS` The component(s). In the old format, this would usually be the remainder of the line after the "suite." If the suite ends with a `/`, this is unused.~~

These existing variables are also used:
* `APT_LIST_NAME` This variable is still used to create the name of the file, but with the `.sources` extension.
~~* `APT_REPO_OPTIONS` This still contains the options, but you need to specify them in the new format. 
 For example `"Architectures: amd64"` instead of `"arch=amd64"`~~
* `ASC_KEY_URL`, `GPG_KEY_URL` and `GPG_KEY_ID` work exactly the same as normal.
 
 ~~For some examples of how these would be used, here are some modified versions of existing packages that I used for testing:~~
