### PR TITLE
feat: add Aptakube (Kubernetes GUI) package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -10,6 +10,7 @@ android-messages-desktop
 antimicrox
 anydesk
 appimagelauncher
+aptakube
 atom
 atomic
 audio-recorder

--- a/01-main/packages/aptakube
+++ b/01-main/packages/aptakube
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "aptakube/aptakube"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*amd64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL}")
+fi
+PRETTY_NAME="Aptakube"
+WEBSITE="https://aptakube.com/"
+SUMMARY="Desktop client for Kubernetes cluster management."


### PR DESCRIPTION
Adds package definition for [Aptakube](https://aptakube.com/), a desktop client for managing Kubernetes clusters with a graphical interface. Downloads amd64 .deb from GitHub releases at aptakube/aptakube.

Verified: latest release (1.15.2) publishes `aptakube_1.15.2_amd64.deb`.

Closes #1641

This contribution was developed with AI assistance (Claude Code).