### PR TITLE
fix: populate release cache on 'show' for non-installed packages

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -180,7 +180,7 @@ function get_github_releases() {
     #   curl -I https://api.github.com/users/flexiondotorg
 
     # Do not process github releases while generating a pretty list or upgrading
-    if [[ ' install fix-installed ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
+    if [[ ' install fix-installed show ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             if [ -z ${QUIET} ]; then
                 fancy_message info "Updating ${CACHE_FILE}"
@@ -210,7 +210,7 @@ function get_gitlab_releases() {
     # So for gitlab sourced apps that use this release model users can use 99-local to pin a version
     #
 
-    if [[ ' install fix-installed ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
+    if [[ ' install fix-installed show ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             if [ -z ${QUIET} ]; then
                 fancy_message info "Updating ${CACHE_FILE}"
@@ -239,7 +239,7 @@ function get_gitlab_releases() {
 function get_website() {
     METHOD="website"
     CACHE_FILE="${CACHE_DIR}/${APP}.html"
-    if [[ ' install fix-installed ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
+    if [[ ' install fix-installed show ' =~ " ${ACTION} " ]] || { [[ ' update ' =~ " ${ACTION} " ]] && package_is_installed "${APP}"; }; then
         if [ ! -e "${CACHE_FILE}" ] || [ -n "$(find "${CACHE_FILE}" -mmin +"${DEBGET_CACHE_RTN:-60}")" ]; then
             if [ -z ${QUIET} ]; then
                 fancy_message info "Updating ${CACHE_FILE}"


### PR DESCRIPTION
Closes #1842

## Problem

`deb-get show <pkg>` prints empty `Published:` and `Download:` lines when the package is not installed and uses `get_github_releases`, `get_gitlab_releases`, or `get_website`:

```
jet@debian13:~$ deb-get show gb-studio
  [*] WARNING! Cached file /var/cache/deb-get/gb-studio.json_extract is empty or missing.
GB Studio
  Package:      gb-studio
  Repository:   01-main
  Updater:      deb-get
  Installed:    No
  Published:
  Architecture: amd64 arm64
  Download:
  Website:      https://www.gbstudio.dev/
  Summary:      ...
```

Per-package scripts like `01-main/packages/gb-studio` derive `URL` and `VERSION_PUBLISHED` by reading `${CACHE_FILE}`, but since #1419 the cache is only populated for `install`, `fix-installed`, and `update` (the latter only when the package is already installed). `show` was not in that allowlist, so for non-installed packages the cache file never existed, the grep in the package definition returned nothing, and the two lines came out blank.

## Fix

Add `show` to the action allowlist in `get_github_releases`, `get_gitlab_releases`, and `get_website`. The existing "no cache for apps we never install" guarantee (no fetching during `list`, `prettylist`, `csvlist`, `search`, etc.) is preserved.

## Testing

- `bash -n deb-get` passes
- The three helpers are the only places where cache population is gated by `${ACTION}`; the same pattern is applied consistently across all three

## Scope notes

- No change for `list`, `prettylist`, `csvlist`, `search`, `remove`, `purge` — cache is still not fetched during those actions
- No change for packages that use `direct` sources — they do not depend on the cache file
- Per-hour cache reuse (`DEBGET_CACHE_RTN`) still applies, so repeated `show` calls won't hammer GitHub / GitLab APIs
