### PR TITLE
feat: add tlrc package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -372,6 +372,7 @@ ticktick
 tidal-hifi
 tinygo
 tixati
+tlrc
 tofu
 tonelib-bassdrive
 tonelib-gfx

--- a/01-main/packages/tlrc
+++ b/01-main/packages/tlrc
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_github_releases "tldr-pages/tlrc" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*x86_64-unknown-linux-gnu\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="tlrc"
+WEBSITE="https://github.com/tldr-pages/tlrc"
+SUMMARY="A tldr client written in Rust with interactive mode and shell completions."


### PR DESCRIPTION
## Summary

- Add a `tlrc` package definition using upstream GitHub Releases.
- Select the GNU/Linux amd64 `.deb` asset.
- Add `tlrc` to the main manifest.

## Validation

- Ran `bash -n 01-main/packages/tlrc`.
- Confirmed the definition resolves the latest amd64 `.deb` URL and published version from GitHub release JSON.
- Downloaded the current amd64 `.deb` and confirmed `Package: tlrc` with `dpkg-deb -f`.

Closes #1627
