### PR TITLE
fix: complete repo names in shell completions

### DIFF
--- a/deb-get.fish
+++ b/deb-get.fish
@@ -44,7 +44,7 @@ complete -c deb-get -f -n "__fish_seen_subcommand_from list" -a "--not-installed
 
 # pretty_list / prettylist / csv_list / csvlist / csv: repo names
 complete -c deb-get -f -n "__fish_seen_subcommand_from pretty_list prettylist csv_list csvlist csv" \
-    -a "(find /etc/deb-get -maxdepth 1 \( -name '*.repo' ! -name '00-builtin.repo' ! -name '99-local.repo' -type f \) -o \( -name '99-local.d' -type d \) -printf '%f\n' 2>/dev/null | sed 's/\\.repo\$//; s/\\.d\$//')"
+    -a "(find /etc/deb-get -maxdepth 1 \( \( -name '*.repo' ! -name '00-builtin.repo' ! -name '99-local.repo' -type f \) -o \( -name '99-local.d' -type d \) \) -printf '%f\n' 2>/dev/null | sed 's/\\.repo\$//; s/\\.d\$//')"
 complete -c deb-get -f -n "__fish_seen_subcommand_from pretty_list prettylist csv_list csvlist csv" \
     -a "00-builtin 01-main"
 

--- a/deb-get_completion
+++ b/deb-get_completion
@@ -27,7 +27,7 @@ function _deb-get() {
         elif [ "${command}" = list ]; then
             COMPREPLY=($(compgen -W "--include-unsupported --raw --installed --not-installed" "\\${COMP_WORDS[${COMP_CWORD}]}"))
         elif [ "${COMP_CWORD}" = 2 ] && [[ " pretty_list prettylist csv_list csvlist csv " =~ " ${command} " ]]; then
-            COMPREPLY=($(compgen -W "$(find "/etc/deb-get" -maxdepth 1 \( -name *.repo ! -name 00-builtin.repo ! -name 99-local.repo -type f \) -o \( -name 99-local.d -type d \) -printf "%f\n" 2> /dev/null | sed "s/.repo$//; s/.d$//" | tr "\n" " ") 00-builtin 01-main" "${COMP_WORDS[2]}"))
+            COMPREPLY=($(compgen -W "$(find "/etc/deb-get" -maxdepth 1 \( \( -name '*.repo' ! -name '00-builtin.repo' ! -name '99-local.repo' -type f \) -o \( -name '99-local.d' -type d \) \) -printf "%f\n" 2> /dev/null | sed "s/.repo$//; s/.d$//" | tr "\n" " ") 00-builtin 01-main" "${COMP_WORDS[2]}"))
         elif [ "${COMP_CWORD}" = 2 ] && [ "${command}" = fix-installed ]; then
             COMPREPLY=($(compgen -W "--old-apps" "\\${COMP_WORDS[2]}"))
         fi


### PR DESCRIPTION
## Summary

- Fix repo-name completion for Bash and fish so `.repo` files are printed by the `find` command.
- Group the `find` alternatives before `-printf`, and quote the name patterns in the Bash completion.

## Validation

- Ran `bash -n deb-get_completion`.
- Verified the corrected `find` expression against a synthetic deb-get config directory containing `.repo` files and `99-local.d`.

Closes #1787
