### PR TITLE
feat: add neoregex package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -242,6 +242,7 @@ nekoray
 nemo-mediainfo-tab
 neo4j
 neo-htop
+neoregex
 net.downloadhelper.coapp
 nextcloud-desktop
 nfpm

--- a/01-main/packages/neoregex
+++ b/01-main/packages/neoregex
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_github_releases "Irineu333/NeoRegex" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*x86_64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="NeoRegex"
+WEBSITE="https://github.com/Irineu333/NeoRegex"
+SUMMARY="A cross-platform app to create and validate regular expressions."


### PR DESCRIPTION
## Summary

- Add a `neoregex` package definition using upstream GitHub Releases.
- Select the amd64 `.deb` asset published by NeoRegex.
- Add `neoregex` to the main manifest.

## Validation

- Ran `bash -n 01-main/packages/neoregex`.
- Confirmed the definition resolves the latest amd64 `.deb` URL and published version from GitHub release JSON.
- Downloaded the current amd64 `.deb` and confirmed `Package: neoregex` with `dpkg-deb -f`.

Closes #1629
