### PR TITLE
feat: add chezmoi package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -37,6 +37,7 @@ bruno
 caddy
 caprine
 #cawbird
+chezmoi
 chronograf
 clamav
 code

--- a/01-main/packages/chezmoi
+++ b/01-main/packages/chezmoi
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64 armhf i386"
+get_github_releases "twpayne/chezmoi" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*linux_${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}")
+fi
+PRETTY_NAME="chezmoi"
+WEBSITE="https://www.chezmoi.io/"
+SUMMARY="Manage your dotfiles across multiple diverse machines, securely."

--- a/01-main/packages/chezmoi
+++ b/01-main/packages/chezmoi
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64 arm64 armhf i386"
 get_github_releases "twpayne/chezmoi" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*linux_${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
-    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}")
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="chezmoi"
 WEBSITE="https://www.chezmoi.io/"


### PR DESCRIPTION
## Summary

- Add a `chezmoi` package definition using upstream GitHub Releases.
- Support the Debian package assets published for `amd64`, `arm64`, `armhf`, and `i386`.
- Add `chezmoi` to the main manifest.

## Validation

- Ran `bash -n 01-main/packages/chezmoi`.
- Confirmed the definition resolves the latest amd64 `.deb` URL and published version from GitHub release JSON.
- Downloaded the current amd64 `.deb` and confirmed `Package: chezmoi` with `dpkg-deb -f`.

Closes #1561
