### PR TITLE
feat: add openboardview package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -263,6 +263,7 @@ onedriver
 onefetch
 onlyoffice-desktopeditors
 openaudible
+openboardview
 openrazer-meta
 openrgb
 opera-stable

--- a/01-main/packages/openboardview
+++ b/01-main/packages/openboardview
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_github_releases "OpenBoardView/OpenBoardView" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*_amd64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}")
+fi
+PRETTY_NAME="Open Board Viewer"
+WEBSITE="https://openboardview.org/"
+SUMMARY="A viewer for electronic board files with annotations and search."

--- a/01-main/packages/openboardview
+++ b/01-main/packages/openboardview
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64"
 get_github_releases "OpenBoardView/OpenBoardView" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*_amd64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
-    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}")
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="Open Board Viewer"
 WEBSITE="https://openboardview.org/"


### PR DESCRIPTION
## Summary

- Add an `openboardview` package definition using upstream GitHub Releases.
- Select the amd64 `.deb` asset published by OpenBoardView.
- Add `openboardview` to the main manifest.

## Validation

- Ran `bash -n 01-main/packages/openboardview`.
- Confirmed the definition resolves the latest amd64 `.deb` URL and published version from GitHub release JSON.
- Downloaded the current amd64 `.deb` and confirmed `Package: openboardview` with `dpkg-deb -f`.

Closes #1752
