### PR TITLE
feat(add package): opencode

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -263,6 +263,7 @@ onedriver
 onefetch
 onlyoffice-desktopeditors
 openaudible
+opencode
 openrazer-meta
 openrgb
 opera-stable

--- a/01-main/packages/opencode
+++ b/01-main/packages/opencode
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "anomalyco/opencode" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*opencode-desktop-linux-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL/v/}")
+fi
+PRETTY_NAME="opencode"
+WEBSITE="https://opencode.ai/"
+SUMMARY="The open source coding agent."


### PR DESCRIPTION
Resolves #1856.

[opencode](https://opencode.ai/) is an open source coding agent that publishes authoritative `.deb` packages for `amd64` and `arm64` from GitHub Releases at [`anomalyco/opencode`](https://github.com/anomalyco/opencode/releases) (the new home of `sst/opencode`; the old URL 301-redirects to the new one).

Package definition derived from @zackattackz's draft in #1856.

## Validation

Verified the URL extraction logic against the live JSON for `v1.14.25` (pretty-printed via `jq`, as `get_github_releases` does):

```
HOST_ARCH=amd64 -> URL=...releases/download/v1.14.25/opencode-desktop-linux-amd64.deb -> VERSION_PUBLISHED=1.14.25
HOST_ARCH=arm64 -> URL=...releases/download/v1.14.25/opencode-desktop-linux-arm64.deb -> VERSION_PUBLISHED=1.14.25
```

The grep pattern terminates with `\.deb"` so it does not match the `.deb.sig` signature assets, the `opencode-electron-linux-*.deb` Electron variants, or the `.rpm` Fedora assets in the same release.