### PR TITLE
feat(add package): gram

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -142,6 +142,7 @@ goreleaser
 goreleaser-pro
 #gotop
 gpu-viewer
+gram
 grub-customizer
 grype
 haguichi

--- a/01-main/packages/gram
+++ b/01-main/packages/gram
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_website "https://codeberg.org/GramEditor/gram/releases.rss"
+if [ "${ACTION}" != "prettylist" ]; then
+    VERSION_PUBLISHED=$(grep -m 1 -e 'guid' "${CACHE_FILE}" | sed -n 's#.*releases/tag/v\{0,1\}\([^<]*\).*#\1#p')
+    URL="https://codeberg.org/GramEditor/gram/releases/download/${VERSION_PUBLISHED}/gram_${VERSION_PUBLISHED}-1_x86_64.deb"
+fi
+PRETTY_NAME="Gram"
+WEBSITE="https://gram.liten.app/"
+SUMMARY="Code editor based on a community fork of Zed."

--- a/01-main/packages/gram
+++ b/01-main/packages/gram
@@ -1,5 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64"
+CODENAMES_SUPPORTED="bookworm trixie forky sid jammy noble plucky questing resolute"
 get_website "https://codeberg.org/GramEditor/gram/releases.rss"
 if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED=$(grep -m 1 -e 'guid' "${CACHE_FILE}" | sed -n 's#.*releases/tag/v\{0,1\}\([^<]*\).*#\1#p')


### PR DESCRIPTION
Closes #1850.

Adds Gram, a community fork of Zed published on Codeberg, to deb-get's main package list.

## Changes

- `01-main/packages/gram`: new package definition. Follows the existing Codeberg + RSS pattern from `linuxtoys`. `get_website` parses the `releases.rss` feed for the latest tag, then constructs the deterministic asset URL `gram_${VERSION}-1_x86_64.deb`.
- `01-main/manifest`: alphabetically inserts `gram` between `gpu-viewer` and `grub-customizer`.

## Codename / arch filter

The upstream `.deb` (verified with `ar x` + reading `control`) declares `Depends: libc6 (>= 2.35)`. `ARCHS_SUPPORTED="amd64"` matches the only arch upstream ships, and `CODENAMES_SUPPORTED="bookworm trixie forky sid jammy noble plucky questing resolute"` excludes Ubuntu focal (libc6 2.31) and Debian bullseye where apt cannot satisfy the libc bound. This matches the codename-list shape used by other strict-libc packages like `bcompare` and `alsa-scarlett-gui`.

## Verification

- `sh -n 01-main/packages/gram` parses cleanly (no bashisms used).
- Verified the asset URL pattern against tags 1.2.0 and 1.2.1 from the Codeberg releases API — both resolve as `/releases/download/${tag}/gram_${tag}-1_x86_64.deb`.
- Manifest line ordering preserved (alphabetical between `gpu-viewer` and `grub-customizer`).