### PR TITLE
add package: steamguard-cli

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -329,6 +329,7 @@ spotube
 sshpilot
 standard-notes
 starcal3
+steamguard-cli
 steampipe
 stirling-pdf
 strawberry

--- a/01-main/packages/steamguard-cli
+++ b/01-main/packages/steamguard-cli
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "dyc3/steamguard-cli" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="steamguard-cli"
+WEBSITE="https://github.com/dyc3/steamguard-cli"
+SUMMARY="Command line utility for generating Steam 2FA codes and responding to confirmations."


### PR DESCRIPTION
Closes #1863.

steamguard-cli is a command-line utility for generating Steam 2FA codes and responding to Steam Mobile confirmations. Upstream at https://github.com/dyc3/steamguard-cli ships a single amd64 .deb in each GitHub release (e.g. v0.17.1 ships `steamguard-cli_0.17.1-0.deb`).

The package definition follows the established GitHub-releases pattern (see `01-main/packages/alduin` and `01-main/packages/mypass`): grep the release JSON for the .deb URL and extract `VERSION_PUBLISHED` from path segment 8 after stripping leading `v`. Manifest entry placed alphabetically between `starcal3` and `steampipe`.

Tested URL extraction against the v0.17.1 release JSON.