### PR TITLE
Add Harmonoid package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -146,6 +146,7 @@ grub-customizer
 grype
 haguichi
 handy
+harmonoid
 headset
 helio-workstation
 helmwave

--- a/01-main/packages/harmonoid
+++ b/01-main/packages/harmonoid
@@ -1,0 +1,16 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+case ${HOST_ARCH} in
+    amd64)
+        TARGET_ARCH=x86_64;;
+    arm64)
+        TARGET_ARCH=aarch64;;
+esac
+get_github_releases "alexmercerind2/harmonoid-releases" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*linux-${TARGET_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="Harmonoid"
+WEBSITE="https://harmonoid.com/"
+SUMMARY="Music player and library manager built with Material Design."


### PR DESCRIPTION
﻿## Summary

- Add a `harmonoid` package definition for the open App Request in #1871.
- Use the upstream release assets from `alexmercerind2/harmonoid-releases`, which Harmonoid's own build workflow and downloads page use for published Linux `.deb` files.
- Support both `amd64` and `arm64` by mapping deb-get architecture names to Harmonoid's `x86_64` and `aarch64` asset names.

## Validation

- Confirmed #1871 is open and no existing open PR matches Harmonoid.
- Inspected the downloaded `.deb` control metadata: `Package: harmonoid`, `Version: 0.3.22-1`.
- Verified the latest release contains both `harmonoid-linux-x86_64.deb` and `harmonoid-linux-aarch64.deb`, resolving to published version `0.3.22`.
- Ran `bash -n 01-main/packages/harmonoid`.
- Sourced the package definition against sample deb-get cache lines for `amd64` and `arm64` to verify URL/version extraction.
- Ran `git diff --check`.

Not run: full `deb-get install` on Debian/Ubuntu, because this validation environment is Windows.