### PR TITLE
Fix(appimagelauncher): parse version correctly

### DIFF
--- a/01-main/packages/appimagelauncher
+++ b/01-main/packages/appimagelauncher
@@ -2,8 +2,9 @@ DEFVER=2
 ARCHS_SUPPORTED="amd64 armhf arm64"
 get_github_releases "TheAssassin/AppImageLauncher"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v xenial | cut -d '"' -f 4)
-    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}" | cut -d '-' -f 1)
+    case "${UPSTREAM_CODENAME}" in bullseye) local BULLSEYE="bionic_";; esac
+    URL=$(grep "browser_download_url.*${BULLSEYE}${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -E -v "alpha|beta|xenial" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}" | sed -E 's/(.*-[^.]+)\./\1~/; s/(~[^.]+)\./\1+/')
 fi
 PRETTY_NAME="AppImage Launcher"
 WEBSITE="https://github.com/TheAssassin/AppImageLauncher"

--- a/01-main/packages/appimagelauncher
+++ b/01-main/packages/appimagelauncher
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64 armhf arm64"
 get_github_releases "TheAssassin/AppImageLauncher"
 if [ "${ACTION}" != "prettylist" ]; then
     case "${UPSTREAM_CODENAME}" in bullseye) local BULLSEYE="bionic_";; esac
-    URL=$(grep "browser_download_url.*${BULLSEYE}${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -E -v "alpha|beta|xenial" | cut -d '"' -f 4)
+    URL=$(grep -m 1 "browser_download_url.*${BULLSEYE}${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}" | sed -E 's/(.*-[^.]+)\./\1~/; s/(~[^.]+)\./\1+/')
 fi
 PRETTY_NAME="AppImage Launcher"


### PR DESCRIPTION
closes #1862
We weren't grabbing the full version number before, so sometimes `appimagelauncher` wouldn't upgrade.
This fixes that, so that the upgrades work correctly. (Except for Bullseye, which is incompatible with the newer versions, so I keep it on the older version.) 

Alternatively, I also included another commit that filters out the alphas and betas, so that only stable releases can be installed. However, it should be noted that the last stable release was in 2020, and doesn't work properly with some newer AppImages. Not sure if it's worth making an exception to the "stable only" rule or not. So I included both options, so you can merge whichever.