### PR TITLE
fix(appimagelauncher): fix version parsing (stable releases only)

### DIFF
--- a/01-main/packages/appimagelauncher
+++ b/01-main/packages/appimagelauncher
@@ -2,8 +2,9 @@ DEFVER=2
 ARCHS_SUPPORTED="amd64 armhf arm64"
 get_github_releases "TheAssassin/AppImageLauncher"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v xenial | cut -d '"' -f 4)
-    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}" | cut -d '-' -f 1)
+    case "${UPSTREAM_CODENAME}" in bullseye) local BULLSEYE="bionic_";; esac
+    URL=$(grep "browser_download_url.*${BULLSEYE}${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -E -v "alpha|beta|xenial" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}" | sed -E 's/(.*-[^.]+)\./\1~/; s/(~[^.]+)\./\1+/')
 fi
 PRETTY_NAME="AppImage Launcher"
 WEBSITE="https://github.com/TheAssassin/AppImageLauncher"


### PR DESCRIPTION
Taking just the stable commit for merging to main.
Closes #1873 
Fixes #1862 

