### PR TITLE
feat: add RapidRAW

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -303,6 +303,7 @@ quickemu
 quickgui
 #quickobs
 rambox
+rapid-raw
 rclone
 rclone-ui
 rcloneview

--- a/01-main/packages/rapid-raw
+++ b/01-main/packages/rapid-raw
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "CyberTimon/RapidRAW" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*ubuntu-24.04.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="RapidRAW"
+WEBSITE="https://github.com/CyberTimon/RapidRAW"
+SUMMARY="A blazingly-fast, non-destructive, and GPU-accelerated RAW image editor."


### PR DESCRIPTION
## Summary

Adds a `rapid-raw` package definition for [RapidRAW](https://github.com/CyberTimon/RapidRAW), a GPU-accelerated RAW image editor published as a .deb on each GitHub release.

Closes #1874

## Why

RapidRAW publishes signed releases on GitHub with prebuilt .debs for both amd64 and arm64 on Ubuntu 22.04 and 24.04, which is exactly the shape `deb-get` is for, and it isn't yet packaged in any official Ubuntu / Debian apt repo. The maintainer requested it in #1874.

## Notes for the reviewer

- `Package:` name in the upstream control file is `rapid-raw` (verified by extracting `control` from `03_RapidRAW_v1.5.5_ubuntu-24.04_amd64.deb`), so the definition file is named to match exactly per `EXTREPO.md`.
- Each release publishes 4 .debs (`ubuntu-22.04_amd64`, `ubuntu-22.04-arm_arm64`, `ubuntu-24.04_amd64`, `ubuntu-24.04-arm_arm64`). The grep is pinned to `ubuntu-24.04` with `${HOST_ARCH}` so it resolves to exactly one asset per host arch.
- `ARCHS_SUPPORTED="amd64 arm64"` covers both supported architectures.
- Added `rapid-raw` to `01-main/manifest` alphabetically between `rambox` and `rclone`.
- Did not regenerate `README.md` (per CONTRIBUTING.md, maintainers regenerate it).
