### PR TITLE
fix(gitkraken): parse VERSION_PUBLISHED from CDN redirect

### DIFF
--- a/01-main/packages/gitkraken
+++ b/01-main/packages/gitkraken
@@ -1,9 +1,16 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64"
-get_website "https://www.gitkraken.com/download/linux-deb"
-URL=$(grep -m 1 -o "https://[^']*\.deb" "${CACHE_FILE}")
+URL="https://api.gitkraken.dev/releases/production/linux/x64/active/gitkraken-amd64.deb"
+# Resolve the "active" alias to its versioned target. HEAD returns 404 on
+# this CDN, so we use a ranged GET (1 byte) instead of unroll_url.
+#shellcheck disable=SC2155
+function follow_url() {
+    local TRIM_URL=$(curl -w "%{url_effective}" --range 0-0 -L -s -S "${1}" -o /dev/null)
+    printf '%s' "${TRIM_URL}"
+}
 if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED=$(sed -n -E "s/.*name:\s*'([^']*)'.*/\1/p" "${CACHE_FILE}")
+    RESOLVED_URL=$(follow_url "${URL}")
+    VERSION_PUBLISHED=$(sed -n -E 's|.*/x64/([0-9.]+)/.*|\1|p' <<< "${RESOLVED_URL}")
 fi
 PRETTY_NAME="GitKraken"
 WEBSITE="https://www.gitkraken.com/git-client"


### PR DESCRIPTION
## Summary
The gitkraken plugin has been reporting `Published: 11.9.0` for months while upstream is at 12.1.2. The version is currently scraped from a `name: '11.9.0'` JavaScript blob on the download page that the vendor no longer updates.

This switches to resolving the canonical `.../active/gitkraken-amd64.deb` URL — the CDN redirects to `.../x64/<VERSION>/<token>/gitkraken-amd64.deb`, so we pluck the version out of the resolved URL.

`unroll_url` uses HEAD, which returns 404 here, so I inlined a small `follow_url` using `--range 0-0` (same pattern as `bitwig-studio`).

Related: closed #1248 (empty VERSION_PUBLISHED — same root cause class).

## Test plan
- [x] `curl -w "%{url_effective}" --range 0-0 -L -s -S "$URL" -o /dev/null` resolves to a URL containing `/x64/12.1.2/`
- [x] `sed` extraction yields `12.1.2`
- [x] Plugin syntax valid (sourced cleanly)

Thanks @wimpysworld for `deb-get` — saved me a lot of pain over the years!

🤖 Generated with [Claude Code](https://claude.com/claude-code)