### PR TITLE
fix(update): handle non-existing `${ETC_DIR}/installed` file gracefully

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1628,7 +1628,12 @@ function dg_action_update() {
                     remove_installed "${APP}"
                 fi
             done
-            mapfile -t INSTALLED_APPS <"${ETC_DIR}/installed"; INSTALLED_APPS=("${INSTALLED_APPS[@]%% *}")
+            if [ -s "${ETC_DIR}/installed" ]; then
+                mapfile -t INSTALLED_APPS <"${ETC_DIR}/installed"
+                INSTALLED_APPS=("${INSTALLED_APPS[@]%% *}")
+            else
+                INSTALLED_APPS=()
+            fi
             update_debs
         fi
 }


### PR DESCRIPTION
The `${ETC_DIR}/installed` file might not yet exist after a fresh installation (e.g. when installing from source via `make install`), so we have to account for this.