### PR TITLE
fix(gram): switch to Apt Repo method

### DIFF
--- a/01-main/packages/gram
+++ b/01-main/packages/gram
@@ -1,11 +1,8 @@
-DEFVER=1
-ARCHS_SUPPORTED="amd64"
-CODENAMES_SUPPORTED="bookworm trixie forky sid jammy noble plucky questing resolute"
-get_website "https://codeberg.org/GramEditor/gram/releases.rss"
-if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED=$(grep -m 1 -e 'guid' "${CACHE_FILE}" | sed -n 's#.*releases/tag/v\{0,1\}\([^<]*\).*#\1#p')
-    URL="https://codeberg.org/GramEditor/gram/releases/download/${VERSION_PUBLISHED}/gram_${VERSION_PUBLISHED}-1_x86_64.deb"
-fi
+DEFVER=2
+CODENAMES_SUPPORTED="bookworm trixie forky sid noble questing resolute"
+ASC_KEY_URL="https://codeberg.org/api/packages/GramEditor/debian/repository.key"
+APT_REPO_URL="https://codeberg.org/api/packages/GramEditor/debian gram release"
+APT_REPO_OPTIONS="arch=${HOST_ARCH}"
 PRETTY_NAME="Gram"
 WEBSITE="https://gram.liten.app/"
 SUMMARY="Code editor based on a community fork of Zed."


### PR DESCRIPTION
closes #1882 

Also, I removed `jammy` because it is [not supported.](https://codeberg.org/GramEditor/gram/src/branch/main/docs/linux.md)

> Requires Debian 12 (Bookworm)/Ubuntu 24.04 (noble) or later.

To be sure, I also tested it myself, and while it installs, it indeed does not work in jammy.

I also removed `plucky` since it is EOL.