### PR TITLE
Add keymapper package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -190,6 +190,7 @@ kapacitor
 kdiskmark
 keepassxc
 keybase
+keymapper
 kopia-ui
 koodo-reader
 koreader

--- a/01-main/packages/keymapper
+++ b/01-main/packages/keymapper
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "houmain/keymapper" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*Linux-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="keymapper"
+WEBSITE="https://github.com/houmain/keymapper"
+SUMMARY="A cross-platform context-aware key remapper."

--- a/01-main/packages/keymapper
+++ b/01-main/packages/keymapper
@@ -2,7 +2,12 @@ DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
 get_github_releases "houmain/keymapper" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*Linux-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    local ARCHNAME="${HOST_ARCH}"
+    if [ "${HOST_ARCH}" = amd64 ]; then
+        ARCHNAME="${HOST_CPU}"
+    fi
+
+    URL=$(grep "browser_download_url.*Linux-${ARCHNAME}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="keymapper"


### PR DESCRIPTION
Closes #1885

Adds support for keymapper - A cross-platform context-aware key remapper.

- Package: keymapper
- Source: https://github.com/houmain/keymapper
- Download: GitHub Releases (.deb for amd64 and arm64)