### PR TITLE
fix(marktext): upstream have removed arch from package naming

### DIFF
--- a/01-main/packages/marktext
+++ b/01-main/packages/marktext
@@ -2,7 +2,7 @@ DEFVER=1
 ARCHS_SUPPORTED="amd64"
 get_github_releases "marktext/marktext" "latest"
 if [ "${ACTION}" != prettylist ]; then
-    URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="MarkText"


### PR DESCRIPTION
Fixes #1891 