### PR TITLE
fix(install): avoid noise on first use

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -1338,7 +1338,10 @@ function maint_supported_cache() {
 
 function add_installed() {
     local line="${APP} ${DEFVER} ${METHOD}"
-    cat "${ETC_DIR}/installed" - <<< "${line}" | ${ELEVATE} sort -t " " -k 1 -u -o "${ETC_DIR}/installed"
+    {
+        [ -f "${ETC_DIR}/installed" ] && cat "${ETC_DIR}/installed"
+        printf '%s\n' "${line}"
+    } | ${ELEVATE} sort -t " " -k 1 -u -o "${ETC_DIR}/installed"
 }
 
 function remove_installed() {


### PR DESCRIPTION
When running `deb-get install` the very first time, the `/etc/deb-get/installed` file might not yet exist and the command produces the following noisy output:

```
cat: /etc/deb-get/installed: No such file or directory
```

This fix makes the `add_installed` function account for this.