### PR TITLE
fix(koreader): adopt preferred github version derivation

### DIFF
--- a/01-main/packages/koreader
+++ b/01-main/packages/koreader
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64 arm64 armhf armhl"
 get_github_releases "koreader/koreader" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
-    VERSION_PUBLISHED=$(cut -d '-' -f 2 <<< "${URL}")
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="KOReader"
 WEBSITE="https://koreader.rocks/"


### PR DESCRIPTION
Upstream have changed asset naming scheme and so broken the common but vulnerable derivation which now gives a wrong version and generates a warning from dpkg as the version string is invalid.