### PR TITLE
fix(ntfy): the old apt repo has finally closed 

### DIFF
--- a/01-main/packages/ntfy
+++ b/01-main/packages/ntfy
@@ -1,9 +1,9 @@
-DEFVER=1
+DEFVER=2
 ARCHS_SUPPORTED="amd64 arm64 armhf"
-ASC_KEY_URL="https://archive.heckel.io/apt/pubkey.txt"
-APT_REPO_URL="https://archive.heckel.io/apt debian main"
+GPG_KEY_URL="https://archive.ntfy.sh/apt/keyring.gpg"
+APT_REPO_URL="https://archive.ntfy.sh/apt stable main"
 APT_REPO_OPTIONS="arch=${HOST_ARCH}"
-APT_LIST_NAME=heckel.io
+APT_LIST_NAME=ntfy
 PRETTY_NAME="nfty"
 WEBSITE="https://github.com/binwiederhier/ntfy/"
 SUMMARY="ntfy lets you send push notifications to your phone or desktop via scripts from any computer, using simple HTTP PUT or POST requests"


### PR DESCRIPTION
It must be replaced with archive.ntfy.sh
(per https://docs.ntfy.sh/install/#debianubuntu-repository)

fixes #1901