### PR TITLE
feat: add support for episteme (both standard and OSS versions)

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -86,6 +86,8 @@ emptyepsilon
 enpass
 ente
 enteauth
+episteme
+episteme-oss
 espanso
 espanso-wayland
 eversticky

--- a/01-main/packages/episteme
+++ b/01-main/packages/episteme
@@ -1,0 +1,11 @@
+DEFVER=1
+# ARCHS_SUPPORTED="amd64"
+CODENAMES_SUPPORTED="trixie forky sid noble resolute"
+get_github_releases "Aryan-Raj3112/episteme" # "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*episteme-standard.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//desktop-v/}")
+fi
+PRETTY_NAME="Episteme"
+WEBSITE="https://github.com/Aryan-Raj3112/episteme"
+SUMMARY="Episteme is a modern, full-featured document and e-book reader for Android and desktop, built with Kotlin Multiplatform and Compose."

--- a/01-main/packages/episteme-oss
+++ b/01-main/packages/episteme-oss
@@ -1,0 +1,11 @@
+DEFVER=1
+# ARCHS_SUPPORTED="amd64"
+CODENAMES_SUPPORTED="trixie forky sid noble resolute"
+get_github_releases "Aryan-Raj3112/episteme" # "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*episteme-oss.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//desktop-v/}")
+fi
+PRETTY_NAME="Episteme OSS"
+WEBSITE="https://github.com/Aryan-Raj3112/episteme"
+SUMMARY="Episteme OSS is a modern, offline-first, privacy-focused document and e-book reader for Android and desktop, built with Kotlin Multiplatform and Compose."


### PR DESCRIPTION
closes #1906 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

