### PR TITLE
fix: LACT have moved to  debian-13

### DIFF
--- a/01-main/packages/lact
+++ b/01-main/packages/lact
@@ -4,7 +4,7 @@ CODENAMES_SUPPORTED="bookworm trixie jammy noble resolute"
 UPSTREAM_RELEASE_NODOT="${UPSTREAM_RELEASE//./}"
 get_github_releases "ilya-zlobintsev/LACT" # "latest"
 if [ "${ACTION}" != prettylist ]; then
-    URL="$(grep -m 1 "browser_download_url.*lact-[0-9].*${HOST_ARCH}\.${UPSTREAM_ID}-${UPSTREAM_RELEASE_NODOT}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"
+    URL="$(grep -v -e 'test-build' "${CACHE_FILE}" | grep -m 1 "browser_download_url.*lact-[0-9].*${HOST_ARCH}\.${UPSTREAM_ID}-${UPSTREAM_RELEASE_NODOT}\.deb\"" | cut -d '"' -f 4)"
     VERSION_PUBLISHED="$(cut -d '/' -f 8 <<< "${URL//v/}")"
 fi
 PRETTY_NAME="LACT"

--- a/01-main/packages/lact
+++ b/01-main/packages/lact
@@ -1,8 +1,8 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64"
-CODENAMES_SUPPORTED="bookworm jammy noble"
+CODENAMES_SUPPORTED="bookworm trixie jammy noble resolute"
 UPSTREAM_RELEASE_NODOT="${UPSTREAM_RELEASE//./}"
-get_github_releases "ilya-zlobintsev/LACT" "latest"
+get_github_releases "ilya-zlobintsev/LACT" # "latest"
 if [ "${ACTION}" != prettylist ]; then
     URL="$(grep -m 1 "browser_download_url.*lact-[0-9].*${HOST_ARCH}\.${UPSTREAM_ID}-${UPSTREAM_RELEASE_NODOT}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"
     VERSION_PUBLISHED="$(cut -d '/' -f 8 <<< "${URL//v/}")"


### PR DESCRIPTION
Includes release for 26.04
Closes #1757
Closes #1761

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

