### PR TITLE
fix(novelwriter): select appropriate download for codename

### DIFF
--- a/01-main/packages/novelwriter
+++ b/01-main/packages/novelwriter
@@ -1,9 +1,16 @@
 DEFVER=1
-CODENAMES_SUPPORTED="noble oracular plucky questing"
+CODENAMES_SUPPORTED="noble oracular plucky questing resolute stonking bookworm trixie forky sid"
+local DEB_CHOICE=""
 get_github_releases "vkbo/novelWriter" "latest"
+case ${UPSTREAM_CODENAME} in
+    noble|oracular|plucky|bookworm)
+        DEB_CHOICE="-oldstable";;
+    *)
+        DEB_CHOICE="";;
+esac
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
-    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+    URL=$(grep -m 1 "browser_download_url.*[0-9]${DEB_CHOICE}_all\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< ${URL//v/})
 fi
 PRETTY_NAME="novelWriter"
 WEBSITE="https://novelwriter.io"


### PR DESCRIPTION
possibly fixes #1919 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

