### PR TITLE
fix(CI):avoid redundant re-testing of merged definition changes

### DIFF
--- a/.github/workflows/tests-01-main.yml
+++ b/.github/workflows/tests-01-main.yml
@@ -41,8 +41,14 @@ jobs:
           DEPRECATED=$(tail -n +2 01-main/manifest | grep '^#' | sed 's/^#//' | tr '\n' ' ')
 
           if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
-            # Pull request: detect changed package files
-            CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^01-main/packages/" | sed "s|^01-main/packages/||" || true)
+            # Pull request: detect changed package files against the latest default branch HEAD
+            BASE_REF="${{ github.event.repository.default_branch }}"
+            if [ -z "${BASE_REF}" ]; then
+              BASE_REF="main"
+            fi
+
+            git fetch --no-tags --prune --depth=1 origin "${BASE_REF}"
+            CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "origin/${BASE_REF}" "${{ github.sha }}" | grep "^01-main/packages/" | sed "s|^01-main/packages/||" || true)
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # workflow_dispatch: use specified packages or read all from manifest
             INPUT_PACKAGES="${{ github.event.inputs.packages }}"


### PR DESCRIPTION
Updated the detect logic to compare PR changes against the current default branch HEAD (main), not the PR’s stored base SHA.

What changed:

In tests-01-main.yml, the Detect changed packages step now: Resolves the default branch name (falls back to main). Fetches the latest remote tip for that branch. Uses git diff between origin/<default-branch> and the PR head SHA. Key effect:

Already-merged changes on main are no longer re-detected and re-tested just because the PR branch was created earlier. This should reduce redundant package test runs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

