### PR TITLE
Add Pomodorolm package definition

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -297,6 +297,7 @@ plexmediaserver
 plow
 polychromatic
 pomatez
+pomodorolm
 #popcorn-time
 portmaster
 powershell

--- a/01-main/packages/pomodorolm
+++ b/01-main/packages/pomodorolm
@@ -3,7 +3,7 @@ ARCHS_SUPPORTED="amd64"
 get_github_releases "vjousse/pomodorolm" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep -m 1 "browser_download_url.*_amd64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
-    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}")
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//app-v/}")
 fi
 PRETTY_NAME="Pomodorolm"
 WEBSITE="https://github.com/vjousse/pomodorolm"

--- a/01-main/packages/pomodorolm
+++ b/01-main/packages/pomodorolm
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_github_releases "vjousse/pomodorolm" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*_amd64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL}")
+fi
+PRETTY_NAME="Pomodorolm"
+WEBSITE="https://github.com/vjousse/pomodorolm"
+SUMMARY="A simple, good looking and multi-platform pomodoro tracker."


### PR DESCRIPTION
## Description

Adds a package definition for **Pomodorolm** — *a simple, good looking and multi-platform pomodoro tracker*.

Closes #1545.

## Details
- Source: official GitHub releases at [`vjousse/pomodorolm`](https://github.com/vjousse/pomodorolm), which ship an authoritative `amd64` `.deb` (`pomodorolm_0.9.1_amd64.deb`).
- Package type: `get_github_releases` (GitHub releases), modelled on the existing `openboardview` definition.
- `ARCHS_SUPPORTED="amd64"` — upstream only ships an amd64 `.deb`.
- Registered the package in `01-main/manifest` (alphabetically, between `pomatez` and `popcorn-time`).
- `README.md` intentionally left untouched, per CONTRIBUTING (maintainers regenerate it).

## Verification
- Confirmed the upstream `.deb` control fields: `Package: pomodorolm`, `Version: 0.9.1`, `Architecture: amd64` — so `VERSION_PUBLISHED` (`0.9.1`) matches the installed package version.
- `bash -n` passes on the package definition.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

