### PR TITLE
feat: add Navidrome personal streaming service

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -247,6 +247,7 @@ musikcube
 mypass
 nala
 naps2
+navidrome
 nekoray
 nemo-mediainfo-tab
 neo4j

--- a/01-main/packages/navidrome
+++ b/01-main/packages/navidrome
@@ -2,13 +2,7 @@ DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64 armhf"
 get_github_releases "navidrome/navidrome" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    if [ "${HOST_ARCH}" = "amd64" ]; then
-        URL=$(grep "browser_download_url.*linux_amd64\.deb\"" "${CACHE_FILE}" | head -1 | cut -d '"' -f 4)
-    elif [ "${HOST_ARCH}" = "arm64" ]; then
-        URL=$(grep "browser_download_url.*linux_arm64\.deb\"" "${CACHE_FILE}" | head -1 | cut -d '"' -f 4)
-    elif [ "${HOST_ARCH}" = "armhf" ]; then
-        URL=$(grep "browser_download_url.*linux_armv7\.deb\"" "${CACHE_FILE}" | head -1 | cut -d '"' -f 4)
-    fi
+    URL=$(grep -m 1  "browser_download_url.*linux_${HOST_ARCH/hf/v7}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="Navidrome"

--- a/01-main/packages/navidrome
+++ b/01-main/packages/navidrome
@@ -1,0 +1,16 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64 armhf"
+get_github_releases "navidrome/navidrome" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    if [ "${HOST_ARCH}" = "amd64" ]; then
+        URL=$(grep "browser_download_url.*linux_amd64\.deb\"" "${CACHE_FILE}" | head -1 | cut -d '"' -f 4)
+    elif [ "${HOST_ARCH}" = "arm64" ]; then
+        URL=$(grep "browser_download_url.*linux_arm64\.deb\"" "${CACHE_FILE}" | head -1 | cut -d '"' -f 4)
+    elif [ "${HOST_ARCH}" = "armhf" ]; then
+        URL=$(grep "browser_download_url.*linux_armv7\.deb\"" "${CACHE_FILE}" | head -1 | cut -d '"' -f 4)
+    fi
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="Navidrome"
+WEBSITE="https://www.navidrome.org"
+SUMMARY="Your personal streaming service"


### PR DESCRIPTION
Hi,
Let me add `Navidrome`, which provides `deb` packages at github release page.

close #1924 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

