### PR TITLE
Add hugo_extended, hugo_withdeploy and hugo_extended_withdeploy

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -158,6 +158,9 @@ helmwave
 heroic
 #homeassistant-supervised
 hugo
+hugo_extended
+hugo_extended_withdeploy
+hugo_withdeploy
 hydralauncher
 hyper
 hyperfine

--- a/01-main/packages/hugo
+++ b/01-main/packages/hugo
@@ -2,7 +2,7 @@ DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
 get_github_releases "gohugoio/hugo"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v extended | cut -d '"' -f 4)
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 -v -e extended -e withdeploy | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="Hugo"

--- a/01-main/packages/hugo_extended
+++ b/01-main/packages/hugo_extended
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "gohugoio/hugo"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep extended | grep -m 1 -v withdeploy | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="Hugo (extended)"
+WEBSITE="https://gohugo.io/"
+SUMMARY="Open-source static site generator (extended version with Sass/SCSS support)."

--- a/01-main/packages/hugo_extended_withdeploy
+++ b/01-main/packages/hugo_extended_withdeploy
@@ -7,4 +7,4 @@ if [ "${ACTION}" != "prettylist" ]; then
 fi
 PRETTY_NAME="Hugo (extended)"
 WEBSITE="https://gohugo.io/"
-SUMMARY="Open-source static site generator (extended version with Sass/SCSS support)."
+SUMMARY="Open-source static site generator (extended version with support for Sass/SCSS and direct cloud deployment)."

--- a/01-main/packages/hugo_extended_withdeploy
+++ b/01-main/packages/hugo_extended_withdeploy
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "gohugoio/hugo"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 extended_withdeploy | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="Hugo (extended)"
+WEBSITE="https://gohugo.io/"
+SUMMARY="Open-source static site generator (extended version with Sass/SCSS support)."

--- a/01-main/packages/hugo_extended_withdeploy
+++ b/01-main/packages/hugo_extended_withdeploy
@@ -5,6 +5,6 @@ if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep -m 1 extended_withdeploy | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
-PRETTY_NAME="Hugo (extended)"
+PRETTY_NAME="Hugo (extended, with deployment)"
 WEBSITE="https://gohugo.io/"
 SUMMARY="Open-source static site generator (extended version with support for Sass/SCSS and direct cloud deployment)."

--- a/01-main/packages/hugo_withdeploy
+++ b/01-main/packages/hugo_withdeploy
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "gohugoio/hugo"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep withdeploy | grep -m 1 -v extended | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="Hugo (extended)"
+WEBSITE="https://gohugo.io/"
+SUMMARY="Open-source static site generator (extended version with support for direct cloud deployment)."

--- a/01-main/packages/hugo_withdeploy
+++ b/01-main/packages/hugo_withdeploy
@@ -5,6 +5,6 @@ if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | grep withdeploy | grep -m 1 -v extended | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
-PRETTY_NAME="Hugo (extended)"
+PRETTY_NAME="Hugo (with deployment)"
 WEBSITE="https://gohugo.io/"
-SUMMARY="Open-source static site generator (extended version with support for direct cloud deployment)."
+SUMMARY="Open-source static site generator (with support for direct cloud deployment)."


### PR DESCRIPTION
Hugo is currently present as one package. However, it actually offers three more releases:

- (regular: the current hugo package)
- extended: with Sass support
- withdeploy: with support for direct cloud deployment
- extended_withdeploy: with support for Sass and direct cloud deployment

My PR adds the missing releases as new packages and ensures that the regular hugo package really installs just the regular Hugo release.

See the [feature matrix](https://github.com/gohugoio/hugo#editions) for more information.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

