### PR TITLE
feat: add ZapZap package

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -444,6 +444,7 @@ youtube-music
 #yq
 ytdownloader
 yubikey-manager
+zapzap
 zenith
 zettlr
 zoom

--- a/01-main/packages/zapzap
+++ b/01-main/packages/zapzap
@@ -1,0 +1,9 @@
+DEFVER=1
+get_github_releases "rafatosta/zapzap" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*zapzap-.*-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '-' -f 2 <<< "${URL##*/}")
+fi
+PRETTY_NAME="ZapZap"
+WEBSITE="https://rtosta.com/zapzap/"
+SUMMARY="A WhatsApp desktop application with multi-account support and Linux integration."


### PR DESCRIPTION
## Summary

- add a package definition for the official stable ZapZap GitHub release
- register ZapZap in the main package manifest

Closes #1917

## Testing

- `bash -n 01-main/packages/zapzap`
- `shellcheck --shell=bash 01-main/packages/zapzap`
- resolved the current latest-release URL and version (`6.5.2.5`) from the release metadata
- verified the downloaded package control fields: `Package: zapzap`, `Version: 6.5.2.5`, `Architecture: amd64`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

