### PR TITLE
fix(caprine): use maintained release fork

### DIFF
--- a/01-main/packages/caprine
+++ b/01-main/packages/caprine
@@ -1,9 +1,10 @@
-DEFVER=1
-get_github_releases "sindresorhus/caprine"
+DEFVER=2
+get_github_releases "bankjaneo/caprine"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    URL=$(grep -m 1 -o "\"browser_download_url\":[[:space:]]*\"[^\"]*${HOST_ARCH}\.deb\"" "${CACHE_FILE}")
+    URL=${URL%\"}; URL=${URL##*\"}
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="Caprine"
-WEBSITE="https://sindresorhus.com/caprine"
+WEBSITE="https://github.com/bankjaneo/caprine"
 SUMMARY="Elegant Facebook Messenger desktop app."


### PR DESCRIPTION
## Summary
- switch the Caprine package definition to the maintained `bankjaneo/caprine` fork
- bump `DEFVER` because the package source changed
- extract the GitHub asset URL directly from `browser_download_url` before deriving the published version

Fixes #1932.

## Validation
- `git diff --check`
- `bash -n 01-main/packages/caprine`
- `bash -n deb-get`
- verified current `bankjaneo/caprine` release exposes amd64 and arm64 `.deb` assets and parses version `2.61.24`

Note: `01-main/README.md` was not regenerated because `01-main/CONTRIBUTING.md` says maintainers regenerate it after merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

