### PR TITLE
fix(portmaster): name is blank but tag_name has the tag

### DIFF
--- a/01-main/packages/portmaster
+++ b/01-main/packages/portmaster
@@ -1,7 +1,7 @@
 DEFVER=1
 get_website "https://api.github.com/repos/safing/portmaster/releases/latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    VERSION_PUBLISHED=$(sed -n 's/.*"name": *"\([^"]*\)".*/\1/p' "${CACHE_FILE}")
+    VERSION_PUBLISHED=$(sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' "${CACHE_FILE}")
     VERSION_PUBLISHED=${VERSION_PUBLISHED//v/}
     URL="https://updates.safing.io/latest/linux_amd64/packages/Portmaster_${VERSION_PUBLISHED}_amd64.deb"
 fi


### PR DESCRIPTION
fixes #1940 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

