### PR TITLE
Retrieve Gitlab 100 items

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -224,7 +224,7 @@ function get_gitlab_releases() {
                 local GITLAB_PROJECT="${1}"
             fi
             if [[ -n "${2}" ]]; then
-                local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases/${RELEASE}/assets/links"
+                local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases/${RELEASE}/assets/links?per_page=100"
             else
                 local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases"
             fi


### PR DESCRIPTION
This supplements https://github.com/wimpysworld/deb-get/pull/1389 .

assets/links endpoint has pagination and releases with more than 20 assets are not supported well. For now we set per_page=100 so that 100 assets are supported.

Currently the number glab assets is 40, so 100 looks practical.

(For full support we would need joining jq)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

