### PR TITLE
fix(google-chrome): add arm64 support

### DIFF
--- a/01-main/packages/google-chrome-beta
+++ b/01-main/packages/google-chrome-beta
@@ -1,9 +1,9 @@
-DEFVER=1
-ARCHS_SUPPORTED="amd64"
+DEFVER=2
+ARCHS_SUPPORTED="amd64 arm64"
 ASC_KEY_URL="https://dl.google.com/linux/linux_signing_key.pub"
 APT_LIST_NAME="google-chrome"
 APT_REPO_URL="https://dl.google.com/linux/chrome/deb/ stable main"
-APT_REPO_OPTIONS="arch=amd64"
+APT_REPO_OPTIONS="arch=${HOST_ARCH}"
 EULA="By downloading Chrome, you agree to the Google Terms of Service and Chrome and Chrome OS Additional Terms of Service\n - https://policies.google.com/terms\n - https://www.google.co.uk/intl/en/chrome/terms/"
 PRETTY_NAME="Google Chrome Beta"
 WEBSITE="https://www.google.com/chrome/beta/"

--- a/01-main/packages/google-chrome-stable
+++ b/01-main/packages/google-chrome-stable
@@ -1,8 +1,9 @@
-DEFVER=1
+DEFVER=2
+ARCHS_SUPPORTED="amd64 arm64"
 ASC_KEY_URL="https://dl.google.com/linux/linux_signing_key.pub"
 APT_LIST_NAME="google-chrome"
 APT_REPO_URL="https://dl.google.com/linux/chrome/deb/ stable main"
-APT_REPO_OPTIONS="arch=amd64"
+APT_REPO_OPTIONS="arch=${HOST_ARCH}"
 EULA="By downloading Chrome, you agree to the Google Terms of Service and Chrome and Chrome OS Additional Terms of Service\n - https://policies.google.com/terms\n - https://www.google.co.uk/intl/en/chrome/terms/"
 PRETTY_NAME="Google Chrome"
 WEBSITE="https://www.google.com/chrome/"

--- a/01-main/packages/google-chrome-unstable
+++ b/01-main/packages/google-chrome-unstable
@@ -1,9 +1,9 @@
-DEFVER=1
-ARCHS_SUPPORTED="amd64"
+DEFVER=2
+ARCHS_SUPPORTED="amd64 arm64"
 ASC_KEY_URL="https://dl.google.com/linux/linux_signing_key.pub"
 APT_LIST_NAME="google-chrome"
 APT_REPO_URL="https://dl.google.com/linux/chrome/deb/ stable main"
-APT_REPO_OPTIONS="arch=amd64"
+APT_REPO_OPTIONS="arch=${HOST_ARCH}"
 EULA="By downloading Chrome, you agree to the Google Terms of Service and Chrome and Chrome OS Additional Terms of Service\n - https://policies.google.com/terms\n - https://www.google.co.uk/intl/en/chrome/terms/"
 PRETTY_NAME="Google Chrome Dev"
 WEBSITE="https://www.google.com/chrome/dev/?platform=linux&extra=devchannel"


### PR DESCRIPTION
## What
Google has started publishing native `arm64` builds of Google Chrome in its official apt repository (`https://dl.google.com/linux/chrome/deb/`), for the `stable`, `beta` and `unstable` (dev) channels. This was announced in March 2026 ([Chromium blog](http://blog.chromium.org/2026/03/bringing-chrome-to-arm64-linux-devices.html)) and is now live — confirmed by checking the repo's `dists/stable/main/binary-arm64/Packages` index, which lists `google-chrome-stable`, `google-chrome-beta` and `google-chrome-unstable` with `Architecture: arm64`.

Previously these package definitions hardcoded `arch=amd64`, so `deb-get install google-chrome-stable` (and beta/unstable) fails/is blocked on arm64 hosts (e.g. Raspberry Pi, Snapdragon X laptops) even though Google now ships a real `aarch64` build.

## Changes
For `google-chrome-stable`, `google-chrome-beta` and `google-chrome-unstable`:
- Add `ARCHS_SUPPORTED="amd64 arm64"`
- Change `APT_REPO_OPTIONS="arch=amd64"` to `APT_REPO_OPTIONS="arch=${HOST_ARCH}"` (matches the pattern used by other multi-arch packages, e.g. `librewolf`, `jellyfin`, `docker-ce`)
- Bump `DEFVER` since `APT_REPO_OPTIONS` changed (per `EXTREPO.md`)

## Verification
```
$ curl -s https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-arm64/Packages | grep -A2 '^Package: google-chrome'
Package: google-chrome-beta
Version: 151.0.7922.47-1
Architecture: arm64
--
Package: google-chrome-stable
Version: 150.0.7871.186-1
Architecture: arm64
--
Package: google-chrome-unstable
Version: 152.0.7967.2-1
Architecture: arm64
```

I searched existing issues/PRs and didn't find any open ones tracking this.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

