### PR TITLE
fix(alt-sendme): extend support to Resolute

### DIFF
--- a/01-main/.shellcheckrc
+++ b/01-main/.shellcheckrc
@@ -1,0 +1,41 @@
+
+# Look for 'source'd files relative to the checked script,
+# and also look for absolute paths in /mnt/chroot
+#source-path=SCRIPTDIR
+#source-path=/mnt/chroot
+
+# Since 0.9.0, values can be quoted with '' or "" to allow spaces
+#source-path="My Documents/scripts"
+
+# Allow opening any 'source'd file, even if not specified as input
+external-sources=true
+
+# Turn on warnings for unquoted variables with safe values
+enable=quote-safe-variables
+
+# Turn on warnings for unassigned uppercase variables
+enable=check-unassigned-uppercase
+
+# Allow [ ! -z foo ] instead of suggesting -n
+disable=SC2236
+
+# we are using bash
+disable=SC2148
+
+# all these definitions are called within functions in the main script, so we don't want to warn about them being unused
+disable=SC2034
+
+shell=bash
+
+
+#        If no .shellcheckrc is found in any of the parent directories, ShellCheck will look in ~/.shellcheckrc followed by the $XDG_CONFIG_HOME (usually ~/.config/shellcheckrc) on Unix, or %APPDATA%/shellcheckrc  on  Windows.   Only  the
+#        first file found will be used.
+
+#        Note for Snap users: the Snap sandbox disallows access to hidden files.  Use shellcheckrc without the dot instead.
+
+#        Note for Docker users: ShellCheck will only be able to look for files that are mounted in the container, so ~/.shellcheckrc will not be read.
+
+# ENVIRONMENT VARIABLES
+#        The environment variable SHELLCHECK_OPTS can be set with default flags:
+
+#               export SHELLCHECK_OPTS='--shell=bash --exclude=SC2016'

--- a/01-main/packages/alt-sendme
+++ b/01-main/packages/alt-sendme
@@ -1,5 +1,5 @@
 DEFVER=1
-CODENAMES_SUPPORTED="bookworm trixie forky sid jammy noble questing"
+CODENAMES_SUPPORTED="bookworm trixie forky sid jammy noble questing resolute"
 get_github_releases "tonyantony300/alt-sendme" "latest"
 if [ "${ACTION}" != prettylist ]; then
     URL="$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

