### PR TITLE
Add siyuan to the manifest

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -339,6 +339,7 @@ shutter-encoder
 signal-desktop
 simplenote
 simple-pwgen
+siyuan
 skypeforlinux
 slack-desktop
 slackdump

--- a/01-main/packages/siyuan
+++ b/01-main/packages/siyuan
@@ -6,7 +6,7 @@ case "${ARCH}" in
     arm64) ARCH=-linux-arm64 ;;
     *) ;;
 esac
-get_github_releases "siyuan-note/siyuan" 
+get_github_releases "siyuan-note/siyuan" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(sed -E -n "s|.*browser_download_url.*(https.*${ARCH}\.deb).*|\1|p" "${CACHE_FILE}" | head -n 1)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")


### PR DESCRIPTION
It's already in the packages but it's not in the manifest yet. I guess i did not add it in my PR (#1661) for it before.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

