### PR TITLE
feat: add Clockify

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -40,6 +40,7 @@ caprine
 chezmoi
 chronograf
 clamav
+clockify
 code
 codium
 #com.github.tkashkin.gamehub

--- a/01-main/packages/clockify
+++ b/01-main/packages/clockify
@@ -1,0 +1,17 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+case ${HOST_ARCH} in
+    amd64)
+        URL="https://clockify.me/downloads/Clockify_Setup_x64.deb";;
+    arm64)
+        URL="https://clockify.me/downloads/Clockify_Setup_arm64.deb";;
+esac
+if [ "${ACTION}" != prettylist ]; then
+    CONTROL_TMP=$(mktemp)
+    curl -sL -r 0-524288 "${URL}" -o "${CONTROL_TMP}"
+    VERSION_PUBLISHED=$(ar p "${CONTROL_TMP}" control.tar.xz | tar -xJO ./control | grep -m 1 -oP '^Version:\s*\K.*')
+    rm -f "${CONTROL_TMP}"
+fi
+PRETTY_NAME="Clockify"
+WEBSITE="https://clockify.me/"
+SUMMARY="Free time tracking app for teams to track work hours across projects."


### PR DESCRIPTION
# feat: add Clockify

Closes #1956.

Adds `01-main/packages/clockify`, a direct-download package for [Clockify](https://clockify.me/), a free time tracking app for teams.

Supports `amd64` and `arm64`.

Clockify doesn't publish its version anywhere on its website or in the download URL (the URL is static: `Clockify_Setup_x64.deb` / `Clockify_Setup_arm64.deb`). A prior attempt to add this package (#652) was rejected for hardcoding `VERSION_PUBLISHED`, per the contribution guidelines requiring a reliable dynamic way to determine the published version.

This definition avoids hardcoding by fetching only the first 512KB of the `.deb` via an HTTP range request, extracting `control.tar.xz` with `ar`, and reading the real `Version:` field from the package's own control file. This reflects the actual `dpkg` version (e.g. `2.7.0-4576`) rather than the marketing version shown on the website (e.g. `2026.1`), and updates automatically as new versions are published.

Verified locally with a redirected `ETC_DIR` (no system changes): `deb-get show clockify` correctly resolves the arch-specific URL and reports the live published version.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

