### PR TITLE
fix: add dash-beam

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -4,7 +4,7 @@ activitywatch
 agena
 #alduin
 alsa-scarlett-gui
-alt-sendme
+#alt-sendme
 amdgpu-top
 android-messages-desktop
 antimicrox
@@ -51,6 +51,7 @@ crossover
 cryptomator
 cudatext
 cw-tail
+dash-beam
 davmail
 dbeaver-ce
 dbgate

--- a/01-main/packages/dash-beam
+++ b/01-main/packages/dash-beam
@@ -1,0 +1,11 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+CODENAMES_SUPPORTED="bookworm trixie forky sid jammy noble questing resolute"
+get_github_releases "tonyantony300/dashbeam" "latest"
+if [ "${ACTION}" != prettylist ]; then
+    URL="$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)"
+    VERSION_PUBLISHED="$(cut -d '/' -f 8 <<< "${URL//v/}")"
+fi
+PRETTY_NAME="DashBeam"
+WEBSITE="https://dashbeam.net/"
+SUMMARY="Send files and folders anywhere in the world without storing in cloud - any size, any format, no accounts, no restrictions."


### PR DESCRIPTION
alt-sendme has been renamed to dash-beam so this
adds the new definition and also deprecates the old name since uninstalling the old app is not managed in packaging.

Closes #1948

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

