### PR TITLE
fix(rstudio): update download metadata source

### DIFF
--- a/01-main/packages/rstudio
+++ b/01-main/packages/rstudio
@@ -1,7 +1,7 @@
 DEFVER=2
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(curl -fsIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb)
+    URL=$(curl -fsSIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb) || URL=""
     VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-\K[0-9.]+\-[0-9]+')
 fi
 PRETTY_NAME="RStudio"

--- a/01-main/packages/rstudio
+++ b/01-main/packages/rstudio
@@ -1,25 +1,8 @@
-DEFVER=1
-CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing"
-get_website "https://posit.co/wp-content/uploads/downloads.json"
-local RELEASE
-local CODENAME
-local ALL_RELEASES
+DEFVER=2
+CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
-    ALL_RELEASES=$(jq -r '.rstudio.open_source.stable.desktop.installer[] | select(.platform.name | contains("Ubuntu") or contains("Debian")) | [.platform.name, .platform.key] | join(",")' "${CACHE_FILE}")
-    case "${UPSTREAM_CODENAME}" in
-        sid) RELEASE=$(grep -E -o "Debian [0-9]+" <<< "${ALL_RELEASES}" | cut -d ' ' -f 2 | sort -rn | head -n 1);;
-          *) RELEASE="${UPSTREAM_RELEASE%%.*}";;
-    esac
-    while [[ ${RELEASE} -gt 0 ]]; do
-        CODENAME=$(grep -i -m 1 -E -o "${UPSTREAM_ID} ${RELEASE}[^,]*,[[:alnum:]]+" <<< "${ALL_RELEASES}")
-        if [[ ${CODENAME} =~ ${UPSTREAM_ID^}\ ${RELEASE}[^,]*,[a-z]+ ]]; then break; fi
-        RELEASE=$((RELEASE - 1))
-    done
-    CODENAME=$(cut -d ',' -f 2 <<< "${CODENAME}")
-    if [ -n "${CODENAME}" ]; then
-        URL=$(jq -r ".rstudio.open_source.stable.desktop.installer.${CODENAME}.url" "${CACHE_FILE}")
-        VERSION_PUBLISHED=$(jq -r ".rstudio.open_source.stable.desktop.installer.${CODENAME}.version" "${CACHE_FILE}")
-    fi
+    URL=$(curl -sIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb)
+    VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-\K[0-9.]+\-[0-9]+')
 fi
 PRETTY_NAME="RStudio"
 WEBSITE="https://posit.co/"

--- a/01-main/packages/rstudio
+++ b/01-main/packages/rstudio
@@ -2,7 +2,7 @@ DEFVER=2
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(follow_url "https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb")
-    VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-\K[0-9.]+\-[0-9]+')
+    VERSION_PUBLISHED=$(grep -oP 'rstudio-\K[0-9.]+\-[0-9]+' <<< "${URL}")
 fi
 PRETTY_NAME="RStudio"
 WEBSITE="https://posit.co/"

--- a/01-main/packages/rstudio
+++ b/01-main/packages/rstudio
@@ -1,7 +1,7 @@
 DEFVER=2
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(curl -fsSIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb) || URL=""
+    URL=$(follow_url "https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb")
     VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-\K[0-9.]+\-[0-9]+')
 fi
 PRETTY_NAME="RStudio"

--- a/01-main/packages/rstudio
+++ b/01-main/packages/rstudio
@@ -1,7 +1,7 @@
 DEFVER=2
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(curl -sIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb)
+    URL=$(curl -fsIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb)
     VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-\K[0-9.]+\-[0-9]+')
 fi
 PRETTY_NAME="RStudio"

--- a/01-main/packages/rstudio-server
+++ b/01-main/packages/rstudio-server
@@ -2,7 +2,7 @@ DEFVER=2
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(follow_url "https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb")
-    VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-server-\K[0-9.]+\-[0-9]+')
+    VERSION_PUBLISHED=$(grep -oP 'rstudio-server-\K[0-9.]+\-[0-9]+' <<< "$URL" )
 fi
 PRETTY_NAME="RStudio Server"
 WEBSITE="https://posit.co"

--- a/01-main/packages/rstudio-server
+++ b/01-main/packages/rstudio-server
@@ -1,7 +1,7 @@
 DEFVER=2
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(curl -fsIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb)
+    URL=$(curl -fsSIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb) || URL=""
     VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-server-\K[0-9.]+\-[0-9]+')
 fi
 PRETTY_NAME="RStudio Server"

--- a/01-main/packages/rstudio-server
+++ b/01-main/packages/rstudio-server
@@ -1,7 +1,7 @@
 DEFVER=2
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(curl -fsSIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb) || URL=""
+    URL=$(follow_url "https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb")
     VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-server-\K[0-9.]+\-[0-9]+')
 fi
 PRETTY_NAME="RStudio Server"

--- a/01-main/packages/rstudio-server
+++ b/01-main/packages/rstudio-server
@@ -1,25 +1,8 @@
-DEFVER=1
-CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing"
-get_website "https://posit.co/wp-content/uploads/downloads.json"
-local RELEASE
-local CODENAME
-local ALL_RELEASES
+DEFVER=2
+CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
-    ALL_RELEASES=$(jq -r '.rstudio.open_source.stable.server.installer[] | select(.platform.name | contains("Ubuntu") or contains("Debian")) | [.platform.name, .platform.key] | join(",")' "${CACHE_FILE}")
-    case "${UPSTREAM_CODENAME}" in
-        sid) RELEASE=$(grep -E -o "Debian [0-9]+" <<< "${ALL_RELEASES}" | cut -d ' ' -f 2 | sort -rn | head -n 1);;
-          *) RELEASE="${UPSTREAM_RELEASE%%.*}";;
-    esac
-    while [[ ${RELEASE} -gt 0 ]]; do
-        CODENAME=$(grep -i -m 1 -E -o "${UPSTREAM_ID} ${RELEASE}[^,]*,[[:alnum:]]+" <<< "${ALL_RELEASES}")
-        if [[ ${CODENAME} =~ ${UPSTREAM_ID^}\ ${RELEASE}[^,]*,[a-z]+ ]]; then break; fi
-        RELEASE=$((RELEASE - 1))
-    done
-    CODENAME=$(cut -d ',' -f 2 <<< "${CODENAME}")
-    if [ -n "${CODENAME}" ]; then
-        URL=$(jq -r ".rstudio.open_source.stable.server.installer.${CODENAME}.url" "${CACHE_FILE}")
-        VERSION_PUBLISHED=$(jq -r ".rstudio.open_source.stable.server.installer.${CODENAME}.version" "${CACHE_FILE}")
-    fi
+    URL=$(curl -sIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb)
+    VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-server-\K[0-9.]+\-[0-9]+')
 fi
 PRETTY_NAME="RStudio Server"
 WEBSITE="https://posit.co"

--- a/01-main/packages/rstudio-server
+++ b/01-main/packages/rstudio-server
@@ -1,7 +1,7 @@
 DEFVER=2
 CODENAMES_SUPPORTED="bookworm trixie sid forky jammy noble plucky questing resolute"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(curl -sIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb)
+    URL=$(curl -fsIL -o /dev/null -w "%{url_effective}" https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb)
     VERSION_PUBLISHED=$(echo "$URL" | grep -oP 'rstudio-server-\K[0-9.]+\-[0-9]+')
 fi
 PRETTY_NAME="RStudio Server"


### PR DESCRIPTION
Posit used to publish RStudio (Server) stable release metadata in structured JSON format under the URL <https://posit.co/wp-content/uploads/downloads.json>. Since a few days (weeks?), that URL doesn't deliver a JSON file anymore but an error "504 Target in maintenance". I think we have to assume that it doesn't come back online, so need to fetch the data from a different URL.

Instead, we can use the canonical URLs

- https://rstudio.org/download/latest/stable/desktop/jammy/rstudio-latest-amd64.deb
- https://rstudio.org/download/latest/stable/server/jammy/rstudio-server-latest-amd64.deb

which redirect to the AWS S3 URL delivering the latest respective DEB package.

*Update 2026-08-12: Meanwhile, the <https://posit.co/wp-content/uploads/downloads.json> in fact came back online. Nevertheless, I think switching to the URLs above as in this PR would be an improvement as it's way simpler than the custom JSON parsing. The PR also adds `resolute` as a supported Ubuntu codename.*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

