### PR TITLE
fix(gitlab): paginate releases listing endpoint

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -223,6 +223,9 @@ function get_gitlab_releases() {
                 local GITLAB_HOST="https://gitlab.com"
                 local GITLAB_PROJECT="${1}"
             fi
+            # per_page=100 is GitLab's practical max for a single page; this bounds
+            # (but doesn't eliminate) truncation for projects with 100+ releases.
+            # Mirrors the same tradeoff already accepted in #1950 for assets/links.
             if [[ -n "${2}" ]]; then
                 local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases/${RELEASE}/assets/links?per_page=100"
             else

--- a/deb-get
+++ b/deb-get
@@ -226,7 +226,7 @@ function get_gitlab_releases() {
             if [[ -n "${2}" ]]; then
                 local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases/${RELEASE}/assets/links?per_page=100"
             else
-                local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases"
+                local URL="${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT//\//%2F}/releases?per_page=100"
             fi
             wgetcmdarray=(wget -q --no-use-server-timestamps "${URL}" -O- )
             # Only grab the .deb files URLs, but first add newlines, because the JSON is all on one line.


### PR DESCRIPTION
Supplements #1950, which added `per_page=100` to the `assets/links` endpoint but missed the sibling `/releases` listing endpoint (used when no release tag is given). GitLab's API defaults to 20 items per page, so projects with more than 20 releases could have older ones silently dropped from the cache.

One-line fix, same pattern as #1950.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

