### PR TITLE
Check for jq installation before running wget command to get github releases

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -187,7 +187,7 @@ function get_github_releases() {
             fi
             local URL="https://api.github.com/repos/${1}/releases${2:+/$2}"
             wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps "${URL}" -O- )
-            if ! command -v "jq"; then
+            if ! command -v "jq" > /dev/null; then
                 fancy_message error "Please install jq."
                 exit 1
             fi

--- a/deb-get
+++ b/deb-get
@@ -187,6 +187,10 @@ function get_github_releases() {
             fi
             local URL="https://api.github.com/repos/${1}/releases${2:+/$2}"
             wgetcmdarray=(wget  "${HEADERPARAM}" "${HEADERAUTH}" -q --no-use-server-timestamps "${URL}" -O- )
+            if ! command -v "jq"; then
+                fancy_message error "Please install jq."
+                exit 1
+            fi
             "${wgetcmdarray[@]}" | jq . | ${ELEVATE} tee "${CACHE_FILE}" > /dev/null || ( fancy_message warn "Updating ${CACHE_FILE} failed." )
             if [ -f "${CACHE_FILE}" ] && grep "API rate limit exceeded" "${CACHE_FILE}"; then
                 fancy_message warn "Updating ${CACHE_FILE} exceeded GitHub API limits. Deleting it."


### PR DESCRIPTION
Figured out why in a VPS `deb-get` was not installing:  `jq` was not installed! So here's a quick fix that will check for 'jq' installation and display the proper error message so people would know what to do next.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

