### PR TITLE
Update installation command for deb-get

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ release pages.
 Use `deb-get` to install `deb-get`.
 
 ```bash
-sudo apt install curl lsb-release wget
+sudo apt install curl lsb-release wget jq
 curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
 ```
 


### PR DESCRIPTION
Added 'jq' to the installation command for 'deb-get'.

Fix as an alternative to #1964

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

