### PR TITLE
feat: Add prelora-desktop

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -318,6 +318,7 @@ pomodorolm
 #popcorn-time
 portmaster
 powershell
+prelora-desktop
 protonmail-bridge
 protonvpn
 proton-authenticator

--- a/01-main/packages/prelora-desktop
+++ b/01-main/packages/prelora-desktop
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_website "https://prelora.app/downloads/latest.json"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="$(jq -r '.latest_deb_url' "${CACHE_FILE}")"
+    VERSION_PUBLISHED="$(jq -r '.version' "${CACHE_FILE}")"
+fi
+PRETTY_NAME="Prelora"
+WEBSITE="https://prelora.app/"
+SUMMARY="Local-first GTD tasks and live countdown timers for Linux desktop."


### PR DESCRIPTION
## Summary
Add **Prelora** as `prelora-desktop` for `deb-get`.
Closes #1966

- Package script: `01-main/packages/prelora-desktop`
- Resolves `.deb` + version from https://prelora.app/downloads/latest.json via `jq` 
- Website: https://prelora.app/


## Test plan
- [ ] `deb-get show prelora-desktop` / install from a clean Ubuntu
- [ ] Version matches `latest.json`