### PR TITLE
feat: add MetaClean

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -229,7 +229,6 @@ marktext
 master-pdf-editor-5
 mattermost-desktop
 mdview
-
 meta-clean
 media-downloader
 mediathekview

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -229,10 +229,10 @@ marktext
 master-pdf-editor-5
 mattermost-desktop
 mdview
-meta-clean
 media-downloader
 mediathekview
 mergerfs
+meta-clean
 #micro
 microsoft-edge-stable
 min

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -229,6 +229,7 @@ marktext
 master-pdf-editor-5
 mattermost-desktop
 mdview
+
 meta-clean
 media-downloader
 mediathekview

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -229,6 +229,7 @@ marktext
 master-pdf-editor-5
 mattermost-desktop
 mdview
+meta-clean
 media-downloader
 mediathekview
 mergerfs

--- a/01-main/packages/meta-clean
+++ b/01-main/packages/meta-clean
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_github_releases "Moresyl/metaclean" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*_amd64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="MetaClean"
+WEBSITE="https://github.com/Moresyl/metaclean"
+SUMMARY="A free and open-source desktop app that removes metadata from files entirely offline."


### PR DESCRIPTION
## Description

Adds MetaClean, an upstream-maintained offline metadata removal desktop app, using its stable amd64 `.deb` from GitHub Releases.

Closes #1971

## Validation

- Confirmed the Debian package name is `meta-clean` with `dpkg-deb --info`.
- Verified the GitHub Releases resolver selects `MetaClean_0.1.0_amd64.deb` and derives version `0.1.0`.
- Ran `bash -n 01-main/packages/meta-clean`.
- Kept `01-main/manifest` sorted and did not update the generated README.

Disclosure: I maintain MetaClean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

