### PR TITLE
fix(docker-desktop): use appcast.json instead of scraping release notes

### DIFF
--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -1,9 +1,13 @@
 DEFVER=1
 ARCHS_SUPPORTED="amd64"
-get_website "https://docs.docker.com/desktop/release-notes/"
+# The appcast has no "latest" entry; every live release is listed, oldest-first, each
+# with a staged-rollout "Visibility" percentage. Neither document order nor
+# Visibility==100 identifies the newest build, so select on highest BuildNumber.
+# AppVersion-BuildNumber matches the .deb's own Version field.
+get_website "https://desktop.docker.com/linux/main/amd64/appcast.json"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 -o 'https:[^>]*\.deb' "${CACHE_FILE}" )
-    VERSION_PUBLISHED=$(awk 'match($0, /href=#[0-9][^>]*>([^<]*)</, a) { print a[1]; exit }' "${CACHE_FILE}")
+    URL=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | .Artifacts[]? | select(.Type=="deb") | .URL' "${CACHE_FILE}" 2>/dev/null)
+    VERSION_PUBLISHED=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | select(.) | "\(.AppVersion)-\(.BuildNumber)"' "${CACHE_FILE}" 2>/dev/null)
 fi
 PRETTY_NAME="Docker Desktop"
 WEBSITE="https://www.docker.com/products/docker-desktop/"


### PR DESCRIPTION
# fix(docker-desktop): use appcast.json instead of scraping release notes

`docker-desktop` is currently broken on `main` — both `URL` and `VERSION_PUBLISHED`
extraction fail, so the package errors out and is skipped:

```
$ deb-get show docker-desktop
  [!] ERROR! Missing required information of website package docker-desktop:
URL=https://desktop.docker.com/linux/main/amd64/224084/docker-desktop-amd64.deb
VERSION_PUBLISHED=
```

## Two separate failures

**1. `VERSION_PUBLISHED` is empty — this is a regression.**

The current definition uses `awk 'match($0, /re/, a)'`. Three-argument `match()` is a
gawk extension; Debian and Ubuntu ship **mawk** as the default `awk`, which errors:

```
awk: line 1: syntax error at or near ,
```

This is the exact symptom of #1527, which was fixed in 204423ea by switching to
`grep -oP`. That fix was then reverted by 753bface ("chore: standardise coding",
#1546), which restored the broken awk form while removing quotes for style. The bug
has been live on `main` since 2026-03-21.

**2. The scraped `URL` is malformed and 403s.**

`grep -m 1 -o 'https:[^>]*\.deb'` runs greedily across markup on the release-notes
page and drops a path separator:

```
scraped:   https://desktop.docker.com/linux/main/amd64236836/docker-desktop-amd64.deb  → 403
corrected: https://desktop.docker.com/linux/main/amd64/236836/docker-desktop-amd64.deb → 200
```

## Why switch source rather than re-fix the regex

`https://docs.docker.com/desktop/release-notes/` is a rendered docs page, and parsing
it has needed repair repeatedly — 76a32b6c, 61e4c63c, ae633be3, 61a655c4, b60d6ac7
(2022), ace55e44 (2024), cec53f46 (2024), 3ab7cd93 (2025), 204423ea (2025), and now
again. Each fix holds until Docker restyles the page.

`https://desktop.docker.com/linux/main/amd64/appcast.json` is the feed Docker
Desktop's own updater consumes. It is public, unauthenticated, stable in shape, and
gives the version, build number and artifact URL as data rather than markup:

```json
{
  "Items": [
    { "Visibility": "100", "AppVersion": "4.86.0", "BuildNumber": "236216",
      "Artifacts": [ { "URL": "…/236216/docker-desktop-amd64.deb", "Type": "deb" } ] },
    { "Visibility": "99",  "AppVersion": "4.87.0", "BuildNumber": "236836",
      "Artifacts": [ { "URL": "…/236836/docker-desktop-amd64.deb", "Type": "deb" } ] }
  ]
}
```

Two details this exposes that a scrape cannot:

- **Staged rollout.** Entries are oldest-first and carry a `Visibility` percentage.
  The newest build is neither the first entry nor the one at `Visibility: 100`, so
  the definition selects on highest `BuildNumber`. Picking either of the other two
  would currently offer 4.86.0 as an "update" over an installed 4.87.0.
- **`VERSION_PUBLISHED` now matches the package.** `AppVersion-BuildNumber` is
  byte-identical to the `.deb`'s own `Version` field (`4.87.0-236836`). The old bare
  `4.87.0` compared as *older* than an installed `4.87.0-236836` under
  `dpkg --compare-versions`, so a Docker rebuild of the same version was silently
  missed. `deb-get show` also now displays Installed and Published in one format.

Parsing is done with `jq`. That's already a hard requirement: the README lists it in
the install line (`sudo apt install curl lsb-release wget jq`), `get_github_releases`
pipes through it, and b153804 (#1964) made it explicit four days ago with a
`command -v jq` check that errors and exits.

A line-oriented `awk`/`grep` version was tried first and rejected: it depends
on the feed staying pretty-printed, and against a minified copy of the same document it
returned `1.0-1.0` — a silently *wrong* version rather than an empty one. Parsing the
structure removes that whole failure class, which is the point of the change.

## Testing

Ubuntu 24.04 (noble), amd64, deb-get 0.4.7:

```
$ deb-get show docker-desktop
Docker Desktop
  Package:      docker-desktop
  Published:    4.87.0-236836
  Download:     https://desktop.docker.com/linux/main/amd64/236836/docker-desktop-amd64.deb
```

Download URL returns 200 and its SHA256 matches the `Checksum` field in the appcast.

- Selection is order-independent — reversing `Items` yields the same result.
- Identical output against a minified copy of the feed.
- `BuildNumber` is compared with `tonumber`, so build 100 sorts above build 99.
- Single-item feed resolves correctly.
- Empty `Items`, truncated JSON, and non-JSON responses all yield empty values, which
  trip the existing "Missing required information" guard rather than producing a bad
  URL.
- `deb-get prettylist` unaffected (exit 0, row renders).
- `shellcheck` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

