### PR TITLE
fix(localsend): their latest release is apk only hot-fix

### DIFF
--- a/01-main/packages/localsend
+++ b/01-main/packages/localsend
@@ -1,6 +1,6 @@
 DEFVER=1
 ARCHS_SUPPORTED='amd64'
-get_github_releases 'localsend/localsend' 'latest'
+get_github_releases 'localsend/localsend'
 if [ "${ACTION}" != prettylist ]; then
     URL=$(grep -m 1 -o "\"browser_download_url\":[[:space:]]*\"[^\"]*x86-64\.deb\"" "${CACHE_FILE}")
     URL=${URL%\"}; URL=${URL##*\"}


### PR DESCRIPTION
We need to get all releases to find the latest deb 
fixes #1970

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

