### PR TITLE
Fix show update

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -134,9 +134,6 @@ function elevate_privs() {
 }
 
 function create_cache_dir() {
-    if [ -d /var/cache/get-deb ]; then
-        ${ELEVATE} mv /var/cache/get-deb "${CACHE_DIR}"
-    fi
     ${ELEVATE} mkdir -p "${CACHE_DIR}" 2>/dev/null
     ${ELEVATE} chmod 755 "${CACHE_DIR}" 2>/dev/null
 }

--- a/deb-get
+++ b/deb-get
@@ -1504,6 +1504,8 @@ function dg_action_clean() {
 
 }
 function dg_action_show() {
+        elevate_privs
+        create_cache_dir
         for APP in "${@,,}"; do
             FULL_APP=${APPNAME2FULL[$APP]}
             if [ -z "${FULL_APP}" ]; then


### PR DESCRIPTION
`deb-get show` silently fails to update the cache which previously would have been present from any update.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/wimpysworld/deb-get/pull/1979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

