### PR TITLE
added lazyjournal

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -209,6 +209,7 @@ ksnip
 kwaterfoxhelper
 labelprinter-vc500w
 lact
+lazyjournal
 lektra
 lens
 libation

--- a/01-main/packages/lazyjournal
+++ b/01-main/packages/lazyjournal
@@ -2,7 +2,7 @@ DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
 get_github_releases "Lifailon/lazyjournal" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    URL=$(grep -m 1 "browser_download_url.${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="lazyjournal"

--- a/01-main/packages/lazyjournal
+++ b/01-main/packages/lazyjournal
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "Lifailon/lazyjournal" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="lazyjournal"
+WEBSITE="https://pkg.go.dev/github.com/Lifailon/lazyjournal"
+SUMMARY="Terminal user interface for viewing logs from system and containers with support for log highlighting and several filtering modes."

--- a/01-main/packages/lazyjournal
+++ b/01-main/packages/lazyjournal
@@ -2,7 +2,7 @@ DEFVER=1
 ARCHS_SUPPORTED="amd64 arm64"
 get_github_releases "Lifailon/lazyjournal" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
-    URL=$(grep -m 1 "browser_download_url.${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    URL=$(grep -m 1 "browser_download_url.*${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
 fi
 PRETTY_NAME="lazyjournal"


### PR DESCRIPTION
Terminal user interface for viewing logs from journald, auditd, file system, Docker and Podman containers, Compose stacks and Kubernetes pods with support for log highlighting and several filtering modes.  
Is available as .deb for amd64 and arm64.  
https://github.com/Lifailon/lazyjournal  
https://pkg.go.dev/github.com/Lifailon/lazyjournal  
