### PR TITLE
feat(docker-desktop): warn when docker-ce-cli is unavailable

### DIFF
--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -9,16 +9,16 @@ if [ "${ACTION}" != "prettylist" ]; then
     URL=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | .Artifacts[]? | select(.Type=="deb") | .URL' "${CACHE_FILE}" 2>/dev/null)
     VERSION_PUBLISHED=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | select(.) | "\(.AppVersion)-\(.BuildNumber)"' "${CACHE_FILE}" 2>/dev/null)
 fi
-if [ "${ACTION}" == "install" ] && ! package_is_installed "${APP}"; then
+if [ "${ACTION}" == "install" ]; then
     # Of the ten dependencies only docker-ce-cli is absent from the Debian and Ubuntu
     # archives; it comes from Docker's own apt repository, which is why Docker's install
     # instructions open by adding that repository. Apt does abort without it, but not
     # before the ~450MB download, and it reports "Unable to correct problems, you have
     # held broken packages" without naming the dependency that is missing. Warn early so
     # the cause and the remedy are on screen before that.
-    # Test for an installation candidate rather than an installed package, so a user who
-    # has the repository configured but has not installed the CLI is not warned need-
-    # lessly; apt will resolve it for them.
+    # An installed package is its own candidate via /var/lib/dpkg/status, so this stays
+    # quiet both for a user who has the repository but not the CLI, and on re-runs once
+    # docker-desktop is installed.
     # shellcheck disable=SC2168,SC2155
     # as we are in a function context
     local DOCKER_CE_CLI=$(apt-cache policy docker-ce-cli 2>/dev/null | awk '/Candidate:/ {print $2}')

--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -9,15 +9,16 @@ if [ "${ACTION}" != "prettylist" ]; then
     URL=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | .Artifacts[]? | select(.Type=="deb") | .URL' "${CACHE_FILE}" 2>/dev/null)
     VERSION_PUBLISHED=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | select(.) | "\(.AppVersion)-\(.BuildNumber)"' "${CACHE_FILE}" 2>/dev/null)
 fi
-if [ "${ACTION}" == "install" ]; then
+if [ "${ACTION}" == "install" ] && ! package_is_installed "${APP}"; then
     # Of the ten dependencies only docker-ce-cli is absent from the Debian and Ubuntu
     # archives; it comes from Docker's own apt repository, which is why Docker's install
     # instructions open by adding that repository. Apt does abort without it, but not
     # before the ~450MB download, and it reports "Unable to correct problems, you have
     # held broken packages" without naming the dependency that is missing. Warn early so
     # the cause and the remedy are on screen before that.
-    # An installed package is its own candidate via /var/lib/dpkg/status, so this stays
-    # quiet both for a user who has the repository but not the CLI, and on re-runs once
+    # Scope it to a first install, so an up-to-date re-run does not warn about a
+    # dependency it is not about to need. An upgrade on a machine that has since lost
+    # docker-ce-cli is left to apt, which is rare because apt resists removing it while
     # docker-desktop is installed.
     # shellcheck disable=SC2168,SC2155
     # as we are in a function context

--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -9,7 +9,7 @@ if [ "${ACTION}" != "prettylist" ]; then
     URL=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | .Artifacts[]? | select(.Type=="deb") | .URL' "${CACHE_FILE}" 2>/dev/null)
     VERSION_PUBLISHED=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | select(.) | "\(.AppVersion)-\(.BuildNumber)"' "${CACHE_FILE}" 2>/dev/null)
 fi
-if [ "${ACTION}" == "install" ] && ! package_is_installed "${APP}"; then
+if [ "${ACTION}" == "install" ] && ! dpkg-query -W -f='${Status}' "${APP}" 2>/dev/null | grep -q '^install ok installed'; then
     # Of the ten dependencies only docker-ce-cli is absent from the Debian and Ubuntu
     # archives; it comes from Docker's own apt repository, which is why Docker's install
     # instructions open by adding that repository. Apt does abort without it, but not
@@ -19,7 +19,8 @@ if [ "${ACTION}" == "install" ] && ! package_is_installed "${APP}"; then
     # Scope it to a first install, so an up-to-date re-run does not warn about a
     # dependency it is not about to need. An upgrade on a machine that has since lost
     # docker-ce-cli is left to apt, which is rare because apt resists removing it while
-    # docker-desktop is installed.
+    # docker-desktop is installed. Ask dpkg rather than deb-get's own installed list,
+    # which goes stale if the package is removed with apt instead of deb-get.
     # shellcheck disable=SC2168,SC2155
     # as we are in a function context
     local DOCKER_CE_CLI=$(apt-cache policy docker-ce-cli 2>/dev/null | awk '/Candidate:/ {print $2}')

--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -9,6 +9,19 @@ if [ "${ACTION}" != "prettylist" ]; then
     URL=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | .Artifacts[]? | select(.Type=="deb") | .URL' "${CACHE_FILE}" 2>/dev/null)
     VERSION_PUBLISHED=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | select(.) | "\(.AppVersion)-\(.BuildNumber)"' "${CACHE_FILE}" 2>/dev/null)
 fi
+if [ "${ACTION}" == "install" ]; then
+    # Of the dependencies only docker-ce-cli is absent from the distro archive; it comes
+    # from Docker's own apt repository, which is why Docker's install instructions open
+    # by adding it. Check for a candidate rather than an installed package, so a user who
+    # has the repository but not the CLI is not warned needlessly. Without this apt only
+    # fails after the ~450MB download.
+    # shellcheck disable=SC2168,SC2155
+    # as we are in a function context
+    local DOCKER_CE_CLI=$(apt-cache policy docker-ce-cli 2>/dev/null | awk '/Candidate:/ {print $2}')
+    if [ -z "${DOCKER_CE_CLI}" ] || [ "${DOCKER_CE_CLI}" == "(none)" ]; then
+        fancy_message warn "${APP} depends on docker-ce-cli, which no configured repository provides. Install it first with 'deb-get install docker-ce' to add Docker's apt repository, or follow https://docs.docker.com/desktop/setup/install/linux/"
+    fi
+fi
 PRETTY_NAME="Docker Desktop"
 WEBSITE="https://www.docker.com/products/docker-desktop/"
 SUMMARY="The fastest way to containerize applications."

--- a/01-main/packages/docker-desktop
+++ b/01-main/packages/docker-desktop
@@ -9,12 +9,16 @@ if [ "${ACTION}" != "prettylist" ]; then
     URL=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | .Artifacts[]? | select(.Type=="deb") | .URL' "${CACHE_FILE}" 2>/dev/null)
     VERSION_PUBLISHED=$(jq -r '.Items | max_by(.BuildNumber|tonumber) | select(.) | "\(.AppVersion)-\(.BuildNumber)"' "${CACHE_FILE}" 2>/dev/null)
 fi
-if [ "${ACTION}" == "install" ]; then
-    # Of the dependencies only docker-ce-cli is absent from the distro archive; it comes
-    # from Docker's own apt repository, which is why Docker's install instructions open
-    # by adding it. Check for a candidate rather than an installed package, so a user who
-    # has the repository but not the CLI is not warned needlessly. Without this apt only
-    # fails after the ~450MB download.
+if [ "${ACTION}" == "install" ] && ! package_is_installed "${APP}"; then
+    # Of the ten dependencies only docker-ce-cli is absent from the Debian and Ubuntu
+    # archives; it comes from Docker's own apt repository, which is why Docker's install
+    # instructions open by adding that repository. Apt does abort without it, but not
+    # before the ~450MB download, and it reports "Unable to correct problems, you have
+    # held broken packages" without naming the dependency that is missing. Warn early so
+    # the cause and the remedy are on screen before that.
+    # Test for an installation candidate rather than an installed package, so a user who
+    # has the repository configured but has not installed the CLI is not warned need-
+    # lessly; apt will resolve it for them.
     # shellcheck disable=SC2168,SC2155
     # as we are in a function context
     local DOCKER_CE_CLI=$(apt-cache policy docker-ce-cli 2>/dev/null | awk '/Candidate:/ {print $2}')


### PR DESCRIPTION
Follows #1975. Implements the `docker-ce-cli` mitigation @philclifford asked for:

> I look forward to a further PR to implement your mitigation of the possible failure if they do not have the docker repository enabled. For experienced users advising the prior installation of `docker-ce` to get the apt repository enabled would work.

## What it does

Of Docker Desktop's ten dependencies, nine resolve from the distro archive. Only
`docker-ce-cli` comes from Docker's own apt repository — it ships `/usr/bin/docker`,
which Docker Desktop's `postinst` symlinks to `/usr/local/bin/docker`. That one
dependency is the whole reason Docker's install pages open with "Set up Docker's `apt`
repository".

Without it the install already fails safe — nothing half-installs. What it does not do
is explain itself. This is the entire diagnostic a user currently gets:

```
E: Unable to correct problems, you have held broken packages.
```

That names neither `docker-ce-cli` nor Docker's repository, and gives no hint that
deb-get already ships a `docker-ce` package which configures exactly the repository that
provides it. This PR puts the cause and the remedy on screen.

It tests for an installation **candidate**, not an installed package, so a user who has
Docker's repository configured but has not installed the CLI is not warned — apt resolves
it for them. It is also guarded on the package not already being installed, so it stays
quiet on re-runs.

## Correction to an earlier claim

An earlier revision of this description said the check runs before `download_deb` and so
saves the ~450MB transfer. **That was wrong, and I am glad it got tested.** `fancy_message
warn` prints and returns; it does not abort. The download still happens and apt still
fails afterwards. The warning's value is diagnostic only.

I tried making it `fancy_message fatal` to genuinely save the transfer. That works —
exit 1, no download — but the message is invisible, because definitions are sourced at
deb-get:489 with stderr discarded:

```bash
. "${ETC_DIR}/${APP_SRC}.d/${APP}" 2>/dev/null
```

`warn` writes to stdout and survives; `error` and `fatal` write to `>&2` and are
swallowed. So `fatal` from a definition is a silent `exit 1`, which is worse than the
status quo. I have kept `warn` and left the download behaviour alone rather than
introduce a bare `exit` — no package definition currently does that, and it is your call
whether definitions should be able to. Details and a knock-on effect on `winegui` in a
comment below.

## Testing

Tested on **Debian 12.15** in an Incus container — deliberately not the Ubuntu 24.04 host
the previous PR was developed on — with deb-get 0.4.7 installed from the 0.4.7 release.

Baseline, unpatched definition, no Docker repository: downloads all 441M, then fails with
the `held broken packages` error above.

Patched, no Docker repository — cause and remedy named, then the same apt failure:

```
  [*] WARNING! docker-desktop depends on docker-ce-cli, which no configured repository
      provides. Install it first with 'deb-get install docker-ce' to add Docker's apt
      repository, or follow https://docs.docker.com/desktop/setup/install/linux/
E: Unable to correct problems, you have held broken packages.
```

Then following that advice verbatim, on the same container:

```
$ deb-get install docker-ce
→ deb [signed-by=...] https://download.docker.com/linux/debian bookworm stable
→ docker-ce-cli candidate: 5:29.7.2-1~debian.12~bookworm

$ deb-get install docker-desktop
→ Setting up docker-desktop (4.88.1-237512)   # no warning

$ deb-get show docker-desktop
  Installed:  4.88.1-237512
  Published:  4.88.1-237512
```

`deb-get upgrade` reports up to date, a second `install` emits no warning, and `show`,
`list` and `prettylist` are unaffected — the check is guarded on `ACTION == install`.
`shellcheck` reports nothing beyond the SC2034 unused-variable notes inherent to the
definition format. CI's `test-package (docker-desktop)` passes; the warning does not fire
there, because the runners already have Docker's repository configured.

## Re: pinning to supported LTS codenames

Not included here. But I went looking for data, and it points at your third option:

> Or we could not limit by codename as now - iirc there is only one .deb and it works fine on noble+ if their apt repo is in place

That recollection holds. There is a single `amd64` .deb with no codename in its URL, and
the real constraint is the `docker-ce-cli` dependency — which Docker publishes for
**every** Ubuntu codename, interims included, not just LTS:

| suite | latest `docker-ce-cli` |
|---|---|
| ubuntu/noble | `5:26.0.0-1~ubuntu.24.04~noble` |
| ubuntu/plucky | `5:28.1.0-1~ubuntu.25.04~plucky` |
| ubuntu/questing | `5:28.5.1-1~ubuntu.25.10~questing` |
| ubuntu/resolute | `5:29.3.1-1~ubuntu.26.04~resolute` |
| debian/bookworm | `5:23.0.0-1~debian.12~bookworm` |
| debian/trixie | `5:28.1.0-1~debian.13~trixie` |

So the `case`-statement mapping — the `winegui` pattern, where an interim falls back to
the prior release — has nothing to map to here: Docker already ships a suite for the
interim itself. Pinning `CODENAMES_SUPPORTED` to LTS only would hide the package from
users on non-LTS paths whose dependency would in fact resolve, which is the outcome your
first concern was guarding against.

That is an argument from what Docker currently publishes rather than what Docker formally
supports, and those differ — the docs still only claim LTS. So it is your call whether
deb-get should advertise beyond Docker's stated support. Happy to send codename pinning
as a separate PR if you would rather be strict; I have left it out of this one either way.
