### PR TITLE
feat: add MPRIS MiniPlayer

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -241,6 +241,7 @@ minikube
 mise
 motrix
 mpdevil
+mpris-miniplayer
 mqttx
 ms-365-electron
 mucommander

--- a/01-main/packages/mpris-miniplayer
+++ b/01-main/packages/mpris-miniplayer
@@ -1,0 +1,10 @@
+DEFVER=1
+CODENAMES_SUPPORTED="trixie forky sid noble plucky questing resolute"
+get_github_releases "ChrisLauinger77/mpris-miniplayer" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="MPRIS MiniPlayer"
+WEBSITE="https://github.com/ChrisLauinger77/mpris-miniplayer"
+SUMMARY="A compact GTK4/libadwaita controller for MPRIS-compatible Linux media players."


### PR DESCRIPTION
Closes #1985.

Adds the upstream-published amd64 Debian package from stable GitHub releases. The definition is limited to distributions that provide the required GTK4, libadwaita, and t64 GLib dependencies.