### PR TITLE
feat: add ToeRings

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -401,6 +401,7 @@ tidal-hifi
 tinygo
 tixati
 tlrc
+toe-rings
 tofu
 tonelib-bassdrive
 tonelib-gfx

--- a/01-main/packages/toe-rings
+++ b/01-main/packages/toe-rings
@@ -1,0 +1,10 @@
+DEFVER=1
+CODENAMES_SUPPORTED="bookworm trixie forky sid jammy noble plucky questing resolute"
+get_github_releases "ChrisLauinger77/toerings" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="ToeRings"
+WEBSITE="https://github.com/ChrisLauinger77/toerings"
+SUMMARY="A lightweight desktop system monitor inspired by Conky Seamod."


### PR DESCRIPTION
Closes #1986.

Adds the upstream-published amd64 Debian package from stable GitHub releases. Supported distributions are limited to releases providing the package's WebKitGTK 4.1 dependency.