### PR TITLE
feat: add RustConn

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -337,6 +337,7 @@ rpi-imager
 r-quick-share
 rstudio
 rstudio-server
+rustconn
 rustdesk
 schildichat-desktop
 sejda-desktop

--- a/01-main/packages/rustconn
+++ b/01-main/packages/rustconn
@@ -1,0 +1,10 @@
+DEFVER=1
+CODENAMES_SUPPORTED="trixie forky sid noble plucky questing resolute"
+get_github_releases "totoshko88/RustConn" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*rustconn_.*_amd64\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="RustConn"
+WEBSITE="https://github.com/totoshko88/RustConn"
+SUMMARY="A modern connection manager for SSH, RDP, VNC, SPICE, and other remote connection protocols."


### PR DESCRIPTION
Closes #1989.

Adds the upstream-published amd64 Debian package from stable GitHub releases. Supported distributions are limited to Debian 13+ and Ubuntu 24.04+ because RustConn requires GTK 4.14 or newer.