### PR TITLE
feat: add Tailcat

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -381,6 +381,7 @@ synology-drive
 system-monitoring-center
 systemd-manager-tui
 tabby-terminal
+tailcat
 tailscale
 tapmap
 tarsnap

--- a/01-main/packages/tailcat
+++ b/01-main/packages/tailcat
@@ -1,0 +1,14 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64 armhf"
+get_github_releases "tailscale/tailcat" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    case "${HOST_ARCH}" in
+        armhf) URL=$(grep -m 1 "browser_download_url.*_linux_armv7\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+               ;;
+        *)     URL=$(grep -m 1 "browser_download_url.*_linux_${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    esac
+    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL##*/}")
+fi
+PRETTY_NAME="Tailcat"
+WEBSITE="https://tailscale.com/tailcat"
+SUMMARY="Like netcat, but over Tailscale's data plane, without Tailscale's control plane."


### PR DESCRIPTION
Closes #1991

## What

Adds a package definition for [Tailcat](https://tailscale.com/tailcat) — like netcat, but over Tailscale's data plane, without Tailscale's control plane.

## Why it qualifies

Per [`01-main/CONTRIBUTING.md`](../blob/main/01-main/CONTRIBUTING.md):

| Criterion | Status |
| --- | --- |
| Published as a `.deb` | ✅ `.deb` assets on every release |
| Published authoritatively by upstream | ✅ `Maintainer: Tailscale Inc. <info@tailscale.com>` |
| Actively maintained | ✅ v0.4.0 released 2026-08-31 |
| Stable/production release only | ✅ uses the `latest` release endpoint |
| Dynamic version detection | ✅ parsed from the GitHub Releases API, no hardcoded version |
| Not in the Debian/Ubuntu archives | ✅ |
| Not part of the HWE stack | ✅ |

## Definition

Follows the GitHub Releases template in [EXTREPO.md](../blob/main/EXTREPO.md), modelled on the existing `duf` definition since upstream uses the same goreleaser asset naming. Upstream ships `linux_amd64`, `linux_arm64` and `linux_armv7`, so `armhf` is mapped to `armv7`; the `armv7` `.deb` correctly declares `Architecture: armhf`.

```bash
DEFVER=1
ARCHS_SUPPORTED="amd64 arm64 armhf"
get_github_releases "tailscale/tailcat" "latest"
if [ "${ACTION}" != "prettylist" ]; then
    case "${HOST_ARCH}" in
        armhf) URL=$(grep -m 1 "browser_download_url.*_linux_armv7\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
               ;;
        *)     URL=$(grep -m 1 "browser_download_url.*_linux_${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
    esac
    VERSION_PUBLISHED=$(cut -d '_' -f 2 <<< "${URL##*/}")
fi
PRETTY_NAME="Tailcat"
WEBSITE="https://tailscale.com/tailcat"
SUMMARY="Like netcat, but over Tailscale's data plane, without Tailscale's control plane."
```

`CODENAMES_SUPPORTED` is omitted: the package is a static Go binary with no `Depends`, so it works on all supported releases.

## Testing

Ran the same steps as the `📦 Package Tests` workflow in a clean `ubuntu:24.04` container:

```
===== list =====
tailcat
OK: tailcat listed
===== install =====
Unpacking tailcat (0.4.0) ...
Setting up tailcat (0.4.0) ...
===== show =====
Tailcat
  Package:      tailcat
  Repository:   01-main
  Updater:      deb-get
  Installed:    0.4.0
  Published:    0.4.0
  Architecture: amd64 arm64 armhf
  Download:     https://github.com/tailscale/tailcat/releases/download/v0.4.0/tailcat_0.4.0_linux_amd64.deb
  Website:      https://tailscale.com/tailcat
  Summary:      Like netcat, but over Tailscale's data plane, without Tailscale's control plane.
===== version match =====
Published=0.4.0 Installed=0.4.0
OK: versions match
===== purge =====
Removing tailcat (0.4.0) ...
OK: purge succeeded
```

Additionally verified:
- URL and version resolve correctly for all three of `amd64`, `arm64` and `armhf`.
- `prettylist` renders the row correctly and skips the `curl`/`grep` work as required.
- `shellcheck` is clean.
- `tailcat --help` runs after install.

README.md is intentionally not updated, per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C45ZUu5pZhh31C4dzgto9i
