### PR TITLE
feat: add AngKorGit

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -6,8 +6,8 @@ agena
 alsa-scarlett-gui
 #alt-sendme
 amdgpu-top
-ang-kor-git
 android-messages-desktop
+ang-kor-git
 antimicrox
 anydesk
 appflowy

--- a/01-main/manifest
+++ b/01-main/manifest
@@ -6,6 +6,7 @@ agena
 alsa-scarlett-gui
 #alt-sendme
 amdgpu-top
+ang-kor-git
 android-messages-desktop
 antimicrox
 anydesk

--- a/01-main/packages/ang-kor-git
+++ b/01-main/packages/ang-kor-git
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64"
+get_github_releases "cheat2001/angkorgit" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*AngKorGit_.*_${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="AngKorGit"
+WEBSITE="https://angkorgit.app/"
+SUMMARY="A modern, fast, beautiful open-source Git client."


### PR DESCRIPTION
## Summary

- add the upstream AngKorGit `amd64` package from GitHub Releases
- resolve the latest stable `.deb` and published version dynamically
- register the package under its Debian package name, `ang-kor-git`

Closes #1993

## Validation

- inspected the official v0.9.0 `.deb` control metadata
- verified release URL resolution and version extraction
- `bash -n 01-main/packages/ang-kor-git`
- `git diff --check`