### PR TITLE
fix(jupyterlab-desktop): match version label to package name

### DIFF
--- a/01-main/packages/jupyterlab-desktop
+++ b/01-main/packages/jupyterlab-desktop
@@ -3,6 +3,7 @@ get_github_releases "jupyterlab/jupyterlab-desktop" "latest"
 if [ "${ACTION}" != "prettylist" ]; then
     URL=$(grep "browser_download_url.*.deb" "${CACHE_FILE}" | cut -d '"' -f 4)
     VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+    VERSION_PUBLISHED="${VERSION_PUBLISHED/-/\~}"
 fi
 PRETTY_NAME="JupyterLab Desktop"
 WEBSITE="https://github.com/jupyterlab/jupyterlab-desktop"


### PR DESCRIPTION
closes #1968