### PR TITLE
feat: add Google Antigravity

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -7,6 +7,7 @@ alsa-scarlett-gui
 #alt-sendme
 amdgpu-top
 android-messages-desktop
+antigravity
 antimicrox
 anydesk
 appflowy

--- a/01-main/packages/antigravity
+++ b/01-main/packages/antigravity
@@ -4,7 +4,7 @@ if [ "${ACTION}" != "prettylist" ]; then
     # The download page is rendered client-side, so the release metadata is read
     # from the update manifest the application itself uses, which also publishes
     # the .deb alongside the AppImage. Both Linux architectures share a build id.
-    ANTIGRAVITY_MANIFEST=$(curl -s "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest/latest-x64-linux.yml")
+    ANTIGRAVITY_MANIFEST=$(curl -sf --max-time 10 --retry 3 "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest/latest-x64-linux.yml")
     URL=$(grep -m 1 -o "https://[^[:space:]]*/linux-x64/Antigravity\.deb" <<< "${ANTIGRAVITY_MANIFEST}")
     if [ "${HOST_ARCH}" == "arm64" ]; then
         URL="${URL/linux-x64/linux-arm}"

--- a/01-main/packages/antigravity
+++ b/01-main/packages/antigravity
@@ -1,0 +1,16 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+if [ "${ACTION}" != "prettylist" ]; then
+    # The download page is rendered client-side, so the release metadata is read
+    # from the update manifest the application itself uses, which also publishes
+    # the .deb alongside the AppImage. Both Linux architectures share a build id.
+    ANTIGRAVITY_MANIFEST=$(curl -s "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest/latest-x64-linux.yml")
+    URL=$(grep -m 1 -o "https://[^[:space:]]*/linux-x64/Antigravity\.deb" <<< "${ANTIGRAVITY_MANIFEST}")
+    if [ "${HOST_ARCH}" == "arm64" ]; then
+        URL="${URL/linux-x64/linux-arm}"
+    fi
+    VERSION_PUBLISHED=$(grep -m 1 "^version:" <<< "${ANTIGRAVITY_MANIFEST}" | cut -d ' ' -f 2)
+fi
+PRETTY_NAME="Google Antigravity"
+WEBSITE="https://antigravity.google"
+SUMMARY="Agentic development platform where AI agents plan, write and verify code."


### PR DESCRIPTION
Adds a package definition for **Google Antigravity 2.0**, Google's agentic development desktop application.

Closes #1998

This is the Antigravity **2.0 agentic desktop app** (`Package: antigravity`, 2.12.0) — not the separate Antigravity IDE (a VS Code fork, 2.5.5, which ships no `.deb`) and not the Antigravity CLI. The two products are served from different hosts and paths, so there is no ambiguity:

| Product | Path | Version |
| --- | --- | --- |
| Antigravity 2.0 (this PR) | `storage.googleapis.com/antigravity-public/antigravity-hub/` | 2.12.0 |
| Antigravity IDE | `edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/` | 2.5.5 |

## Definition

```bash
DEFVER=1
ARCHS_SUPPORTED="amd64 arm64"
if [ "${ACTION}" != "prettylist" ]; then
    # The download page is rendered client-side, so the release metadata is read
    # from the update manifest the application itself uses, which also publishes
    # the .deb alongside the AppImage. Both Linux architectures share a build id.
    ANTIGRAVITY_MANIFEST=$(curl -s "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest/latest-x64-linux.yml")
    URL=$(grep -m 1 -o "https://[^[:space:]]*/linux-x64/Antigravity\.deb" <<< "${ANTIGRAVITY_MANIFEST}")
    if [ "${HOST_ARCH}" == "arm64" ]; then
        URL="${URL/linux-x64/linux-arm}"
    fi
    VERSION_PUBLISHED=$(grep -m 1 "^version:" <<< "${ANTIGRAVITY_MANIFEST}" | cut -d ' ' -f 2)
fi
PRETTY_NAME="Google Antigravity"
WEBSITE="https://antigravity.google"
SUMMARY="Agentic development platform where AI agents plan, write and verify code."
```

## Why the update manifest is used as the version source

The Linux section of https://antigravity.google/download only links the `.tar.gz`, and that page is rendered client-side. It is also served gzip-encoded **regardless of `Accept-Encoding`** (it ignores `identity`), so `get_website` caches compressed bytes that cannot be grepped.

The definition therefore reads the update manifest that the shipped application itself uses — `resources/app-update.yml` points at `.../manifest/`, and electron-updater resolves the channel to `latest-x64-linux.yml`. That manifest lists `Antigravity.deb` by name with its `sha512` and size, alongside the `.AppImage`. Using it means the version source is the same one the application trusts for its own updates.

Both Linux architectures share a single build id, so the `arm64` URL is derived from the same path; I verified the `arm64` package reports `Architecture: arm64`.

## The `.deb` is a first-class artifact

Although it is not linked from the download page, it is a properly formed Google-built package:

- `Maintainer: Google <antigravity-support@google.com>`, `Vendor: Google`
- `update-alternatives` integration for `/usr/bin/antigravity`
- AppArmor profile install/removal and `chrome-sandbox` SUID handling
- Full `md5sums`
- Listed with checksums in Google's own update manifest

## Testing

Replicated `.github/workflows/tests-01-main.yml` in a clean `ubuntu:24.04` container:

```
### in supported list ###
### Published=2.12.0 Installed=2.12.0 ###
RESULT antigravity: pass
```

`list --raw` → `install` → `show` (detected as installed) → published/installed version match → `purge`, all passing. `shellcheck` clean. Also installed and verified on a real Ubuntu 24.04 (noble) host, where all dependencies resolve (the `libgtk-3-0` / `libatspi2.0-0` names are satisfied via the `t64` packages' `Provides`).

README.md intentionally not modified, per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C45ZUu5pZhh31C4dzgto9i
