### PR TITLE
feat: add ChatGPT

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -39,6 +39,7 @@ cable
 caddy
 caprine
 #cawbird
+chatgpt
 chezmoi
 chronograf
 clamav

--- a/01-main/packages/chatgpt
+++ b/01-main/packages/chatgpt
@@ -1,0 +1,11 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+CODENAMES_SUPPORTED="trixie forky sid noble plucky questing resolute"
+get_website "https://persistent.oaistatic.com/codex-app-prod/linux/deb/dists/stable/main/binary-${HOST_ARCH}/Packages"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL="https://persistent.oaistatic.com/codex-app-prod/linux/deb/$(grep -m 1 "^Filename:" "${CACHE_FILE}" | cut -d ' ' -f 2)"
+    VERSION_PUBLISHED=$(grep -m 1 "^Version:" "${CACHE_FILE}" | cut -d ' ' -f 2)
+fi
+PRETTY_NAME="ChatGPT"
+WEBSITE="https://openai.com/codex/"
+SUMMARY="Desktop app for ChatGPT and Codex, OpenAI's AI coding partner."

--- a/01-main/packages/chatgpt
+++ b/01-main/packages/chatgpt
@@ -7,5 +7,5 @@ if [ "${ACTION}" != "prettylist" ]; then
     VERSION_PUBLISHED=$(grep -m 1 "^Version:" "${CACHE_FILE}" | cut -d ' ' -f 2)
 fi
 PRETTY_NAME="ChatGPT"
-WEBSITE="https://openai.com/codex/"
+WEBSITE="https://developers.openai.com/codex/app"
 SUMMARY="Desktop app for ChatGPT and Codex, OpenAI's AI coding partner."


### PR DESCRIPTION
Adds a package definition for the **ChatGPT desktop app**, which ships OpenAI's **Codex** coding agent.

Closes #1999

This is the desktop application, not the `codex` CLI. Upstream names the package `chatgpt` (`/usr/bin/chatgpt` → `codex-launcher`), so the definition file is named to match the `Package:` field as deb-get requires.

## Definition

```bash
DEFVER=1
ARCHS_SUPPORTED="amd64 arm64"
CODENAMES_SUPPORTED="trixie forky sid noble plucky questing resolute"
get_website "https://persistent.oaistatic.com/codex-app-prod/linux/deb/dists/stable/main/binary-${HOST_ARCH}/Packages"
if [ "${ACTION}" != "prettylist" ]; then
    URL="https://persistent.oaistatic.com/codex-app-prod/linux/deb/$(grep -m 1 "^Filename:" "${CACHE_FILE}" | cut -d ' ' -f 2)"
    VERSION_PUBLISHED=$(grep -m 1 "^Version:" "${CACHE_FILE}" | cut -d ' ' -f 2)
fi
PRETTY_NAME="ChatGPT"
WEBSITE="https://openai.com/codex/"
SUMMARY="Desktop app for ChatGPT and Codex, OpenAI's AI coding partner."
```

## Why the direct `.deb` method rather than `APT_REPO_URL`

OpenAI publishes a properly signed apt repository — `InRelease` and `Release.gpg` are both present at `https://persistent.oaistatic.com/codex-app-prod/linux/deb stable main`.

The signing key is not served from any URL: it is embedded as base64 in the package's `postinst`, which decodes it to `/usr/share/keyrings/chatgpt-archive-keyring.gpg` at install time. So `ASC_KEY_URL` and `GPG_KEY_URL` cannot be populated. **`GPG_KEY_ID` would work, though** — the key is on public keyservers:

```
pub   rsa4096 2026-08-05 [SC]
      3BFA0E4AE8B8CC16A2D9BA684A3B4A566C4660E4
uid   Codex Linux Repository
```

I verified a keyserver-fetched copy produces `Good signature` over the live `dists/stable/Release`, and that apt resolves `Candidate: 26.901.20858` through it.

The reason I still went with the direct `.deb` is different: **the package configures that repository itself**, so a deb-get apt-repo definition would register a second entry for the same repo. In a clean container with both present, apt warns on every update:

```
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in
   /etc/apt/sources.list.d/chatgpt.list:1 and /etc/apt/sources.list.d/chatgpt.sources:1
```

Installing the `.deb` directly avoids that duplicate while upgrades still flow through apt via upstream's own entry. The definition uses the `Packages` index's `Filename:` for the URL rather than the `latest/` alias so the downloaded file and reported version can never disagree.

If you would rather have this as `GPG_KEY_ID` + `APT_REPO_URL` and accept the duplicate-source warning (or expect upstream to drop its self-configuration), I am happy to reshape it.

## The package configures that repository itself

Its `postinst` writes `/etc/apt/sources.list.d/chatgpt.sources`, so once installed, `apt` will also offer upgrades. This is upstream's documented behaviour — *"The package configures the signed OpenAI package repository during installation"* — and users can opt out by removing that file. Flagging it because it means the package is effectively co-managed by apt after first install; that is upstream's design, not something this definition introduces.

`CODENAMES_SUPPORTED` reflects upstream's stated support matrix (Ubuntu 24.04+, Debian 13+).

## Testing

Replicated `.github/workflows/tests-01-main.yml` in a clean `ubuntu:24.04` container:

```
### in supported list ###
### Published=26.901.20858 Installed=26.901.20858 ###
RESULT chatgpt: pass
```

`list --raw` → `install` → `show` (detected as installed) → published/installed version match → `purge`, all passing. `shellcheck` clean. Also installed and verified on a real Ubuntu 24.04 (noble) host; the versioned dependencies on `libgtk-3-0`, `libasound2`, `libcups2` and friends all resolve through the `t64` packages' `Provides`, and the repository/keyring are configured as expected.

README.md intentionally not modified, per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C45ZUu5pZhh31C4dzgto9i
