### PR TITLE
Add brave origin

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -32,6 +32,7 @@ blanket
 blockbench
 bottom
 brave-browser
+brave-origin
 brisqi
 browsh
 bruno

--- a/01-main/packages/brave-browser
+++ b/01-main/packages/brave-browser
@@ -1,8 +1,12 @@
-DEFVER=1
+DEFVER=2
+ARCHS_SUPPORTED="amd64 arm64"
 GPG_KEY_URL="https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg"
 APT_LIST_NAME="brave-browser-release"
 APT_REPO_URL="https://brave-browser-apt-release.s3.brave.com/ stable main"
-APT_REPO_OPTIONS="arch=amd64"
+APT_REPO_OPTIONS="arch=amd64,arm64"
 PRETTY_NAME="Brave"
 WEBSITE="https://brave.com/"
 SUMMARY="Browse privately. Search privately. And ditch Big Tech."
+
+
+

--- a/01-main/packages/brave-origin
+++ b/01-main/packages/brave-origin
@@ -1,0 +1,9 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+GPG_KEY_URL="https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg"
+APT_LIST_NAME="brave-browser-release"
+APT_REPO_URL="https://brave-browser-apt-release.s3.brave.com/ stable main"
+APT_REPO_OPTIONS="arch=amd64,arm64"
+PRETTY_NAME="Brave Origin"
+WEBSITE="https://brave.com/origin/"
+SUMMARY="A hardened, privacy-first variant of Brave with no rewards, wallet, or AI features."


### PR DESCRIPTION
Closes #1981 


## What
- Adds `brave-origin`, Brave's privacy-hardened variant (no rewards/wallet/
  AI features), published from the same apt repo as `brave-browser`.
- Declares arm64 support for existing pkg `brave-browser`, which the apt repo has served
  for a while (confirmed via brave.com/linux docs and the live .sources
  file from brave-browser-apt-release.s3.brave.com) but the definition
  never declared. Bumped DEFVER to 2 accordingly.
- Registered `brave-origin` in 01-main/manifest.

## Testing done
- Installed brave-browser and brave-origin side by side on a Debian/amd64.
- Verified `deb-get show` reports correct metadata for both.
- Verified both packages resolve against the shared brave-browser-release.list
  repo file without duplication or conflict.
- Verified `deb-get purge --remove-repo brave-origin` while brave-browser
  remains installed correctly preserves the shared repo file (deb-get's own
  dependency check blocked removal, as expected).
