### PR TITLE
feat: add Sidra

### DIFF
--- a/01-main/manifest
+++ b/01-main/manifest
@@ -351,6 +351,7 @@ sejda-desktop
 sendworm
 session-desktop
 shutter-encoder
+sidra
 signal-desktop
 simplenote
 simple-pwgen

--- a/01-main/packages/sidra
+++ b/01-main/packages/sidra
@@ -1,0 +1,10 @@
+DEFVER=1
+ARCHS_SUPPORTED="amd64 arm64"
+get_github_releases "wimpysworld/sidra" "latest"
+if [ "${ACTION}" != "prettylist" ]; then
+    URL=$(grep -m 1 "browser_download_url.*linux-${HOST_ARCH}\.deb\"" "${CACHE_FILE}" | cut -d '"' -f 4)
+    VERSION_PUBLISHED=$(cut -d '/' -f 8 <<< "${URL//v/}")
+fi
+PRETTY_NAME="Sidra"
+WEBSITE="https://github.com/wimpysworld/sidra"
+SUMMARY="An elegant Apple Music desktop client for Linux, macOS and Windows."


### PR DESCRIPTION
## Summary

- add a Sidra package definition backed by the latest GitHub release
- support the published amd64 and arm64 Debian packages
- register Sidra in the main manifest

Closes #1887

## Testing

- `bash -n 01-main/packages/sidra`
- `git diff --cached --check`
- verified live release URL and version extraction for Sidra 1.1.0